### PR TITLE
Feature/sigil cache support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2018] [Kevin McAbee]
+   Copyright 2018 Kevin McAbee
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Provides functionality around calculating both simple and complex dice rolling e
   upon invocation, such as `1dx+y`.
 * Supports compiling dice rolls into reuseable anonymous functions that be
   passed around and invoked again and again.
-* Supports caching compiled rolls. This can be especially useful in an
-  application that generates variations rolls during runtime.
+* Supports caching compiled rolls. This optional feature can be especially
+  useful in an application that generates various rolls during runtime.
 * Supports exploding dice.
 * Introduces a new sigil, `~a`. This can be used as a shorthand for compiling
   and/or rolling dice rolls, such as `~a/1d6+2-(1d4)d6/`.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,20 @@ Provides functionality around calculating both simple and complex dice rolling e
 
 ## Features
 
+* Simulates dice rolls with any number of dice and sides of dice.
 * Supports common math operators: `+`, `-`, `*`, `/`
 * Supports `+` and `-` unary operators.
-* Supports creating common expressions and parenthetically grouped expressions into complex dice-roll equations.
-* Supports creating uncommon dice rolls, such as `(1d4)d(3d6)-(1d4+7)`.
-* Supports using variables in expressions that can be given values upon use, such as `1dx+y`.
-* Allows developers to tokenize, parse, and then compile dice roll strings into reusable anonymous functions.
+* Supports creating common expressions and parenthetically grouped expressions
+  into complex dice-roll equations, such as `(1d4)d(3d6)-(1d4+7)`.
+* Supports using single-letter variables in expressions that can be given values
+  upon invocation, such as `1dx+y`.
+* Supports compiling dice rolls into reuseable anonymous functions that be
+  passed around and invoked again and again.
+* Supports caching compiled rolls. This can be especially useful in an
+  application that generates variations rolls during runtime.
+* Supports exploding dice.
+* Introduces a new sigil, `~a`. This can be used as a shorthand for compiling
+  and/or rolling dice rolls, such as `~a/1d6+2-(1d4)d6/`.
 
 
 ## Installation
@@ -34,42 +42,87 @@ $ mix deps.get
 ```
 
 
-## Usage
+## General Usage
 
-ExDiceRoller supports a variety of possible dice roll permutations that can be used in your application.
+ExDiceRoller supports a variety of possible dice roll permutations that can be
+used in your application.
 
 ```elixir
-  iex> ExDiceRoller.roll("1")
-  1
+iex> ExDiceRoller.roll("1")
+#=> 1
 
-  iex> ExDiceRoller.roll("1+2")
-  3
+iex> ExDiceRoller.roll("1+2")
+#=> 3
 
-  iex> ExDiceRoller.roll("1d6")
-  1
+iex> ExDiceRoller.roll("1d6")
+#=> 1
 
-  iex> ExDiceRoller.roll("1d20-5")
-  12
+iex> ExDiceRoller.roll("1d20-(5*6)")
+#=> -28
 
-  iex> ExDiceRoller.roll("1d20-(5*6)")
-  -28
+iex> ExDiceRoller.roll("1d4d6")
+#=> 10
 
-  iex> ExDiceRoller.roll("1d4d6")
-  10
+iex> ExDiceRoller.roll("(1d4+2)d(1d20)")
+#=> 22
 
-  iex> ExDiceRoller.roll("(1d4+2)d8")
-  28
+iex> ExDiceRoller.roll("(1d4+2)d((5*6)d20-5)", []) 
+#=> 566
 
-  iex> ExDiceRoller.roll("(1d4+2)d(1d20)")
-  16
+iex> ExDiceRoller.roll("1dx+y", [x: 20, y: 13])
+#=> 16
 
-  iex> ExDiceRoller.roll("(1d4+2)d((5*6)d20-5)")
-  677
-
-  iex> ExDiceRoller.roll("1dx+y", x: 20, y: 13)
-  16
 ```
 
+## Sigil Usage
+
+```elixir
+iex> import ExDiceRoller.Sigil
+#=> ExDiceRoller.Sigil
+
+iex> fun = ~a/1d6+3/
+#=> #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>
+
+iex> ExDiceRoller.execute(fun)
+#=> 6
+
+iex> ~a/1d2+3/r   # compiles the roll and invokes it
+#=> 4
+
+iex> ~a/1d2+2/re  # compiles the roll and invokes it with exploding dice
+#=> 9
+
+iex> ExDiceRoller.roll(~a/2d8-2/)
+#=> 3
+```
+
+## Cache Usage
+
+```elixir
+iex> ExDiceRoller.start_cache()
+#=> {:ok, ExDiceRoller.Cache}
+
+iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: 5], [:cache])
+#=> 34
+
+iex> ExDiceRoller.Cache.all()
+#=> [{"xdy-2d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}]
+
+iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: "2d6"], [:cache])
+#=> 29
+
+iex> ExDiceRoller.Cache.all()
+#=> [{"xdy-2d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}]
+
+iex> ExDiceRoller.roll("1d6+3d4", [], [:cache])
+#=> 10
+
+iex> ExDiceRoller.Cache.all()
+#=> [
+#=>   {"xdy-2d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>},
+#=>   {"1d6+3d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}
+#=> ]
+```
 
 ## Compiled Expressions
 
@@ -77,42 +130,45 @@ Parsed expressions can be compiled into a single, executable anonymous
 function. This function can be reused again and again, with any dice rolls
 being randomized and calculated for each call.
 
-Note that while `ExDiceRoller.roll/1` always returns integers, `ExDiceRoller.execute/1` will
-return either floats or integers.
+Note that while `ExDiceRoller.roll/1` always returns integers,
+`ExDiceRoller.execute/1` will return either floats or integers.
 
 ```elixir
-  iex> {:ok, roll_fun} = ExDiceRoller.compile("1d6 - (3d6)d5 + (1d4)/5")
-  {:ok, #Function<6.11371143/0 in ExDiceRoller.Compiler.compile_op/5>}
+  iex> {:ok, roll_fun} = ExDiceRoller.compile("1d6 - (3d10)d5 + (1d50)/5")
+  #=> {:ok, #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}
 
   iex> ExDiceRoller.execute(roll_fun)
-  21.6
+  #=> -16
 
-  iex> ExDiceRoller.execute(roll_fun)
-  34.4
+  iex> roll_fun.([], [])
+  #=> -43
 
   iex> {:ok, roll_fun} = ExDiceRoller.compile("1dx+10")
-  {:ok, #Function<8.36233920/1 in ExDiceRoller.Compiler.compile_op/5>}
+  #=> {:ok, #Function<8.36233920/1 in ExDiceRoller.Compiler.compile_op/5>}
 
-  iex> ExDiceRoller.execute(roll_fun, x: 5)
-  11
+  iex> ExDiceRoller.execute(roll_fun, [x: 5])
+  #=> 12
 
   iex> ExDiceRoller.execute(roll_fun, x: "10d100")
-  523
+  #=> 523
 ```
 
 
 ## How It Works
 
-1. ExDiceRoller utilizes Erlang's [leex](http://erlang.org/doc/man/leex.html) library to tokenize a given dice roll string.
-2. The tokens are then passed to [yecc](http://erlang.org/doc/man/yecc.html) which parses the tokens into an abstract 
-syntax tree.
+1. ExDiceRoller utilizes Erlang's [leex](http://erlang.org/doc/man/leex.html)
+   library to tokenize a given dice roll string.
+2. The tokens are then passed to [yecc](http://erlang.org/doc/man/yecc.html)
+   which parses the tokens into an abstract syntax tree of expressions.
 3. The syntax tree is then interpreted through recursive navigation.
 4. During interpretation:
-  1. Any basic numerical values are calculated.
-  2. Any dice rolls are converted into anonymous functions.
-  3. Any portion of the expression or equation that use both base values and
+    1. Any basic numerical values are calculated.
+    2. Any dice rolls are converted into anonymous functions.
+    3. Any mathematical operations using numbers are calculated.
+    4. Any mathematical operations using expressions are converted into
+       anonymous functions.
   dice rolls are converted into anonymous functions.
-1. The results of interpretation are then wrapped by a final anonymous
+5. The results of interpretation are then wrapped by a final anonymous
 function.
 6. This final anonymous function is then executed and the value returned.
 
@@ -159,10 +215,10 @@ function.
   iex(6)> {:ok, roll_fun} = ExDiceRoller.compile(ast)
   {:ok, #Function<12.11371143/0 in ExDiceRoller.Compiler.compile_roll/4>}
 
-  iex(7)> roll_fun.()
+  iex(7)> roll_fun.([], [])
   739
 
-  iex(8)> roll_fun.()
+  iex(8)> roll_fun.([], [])
   905
 
   iex(9)> ExDiceRoller.Compiler.fun_info(roll_fun)
@@ -189,5 +245,11 @@ function.
 
 ## Test Coverage and More
 
-* [ex_coveralls](https://github.com/parroty/excoveralls) provides test coverage metrics.
+* [ex_coveralls](https://github.com/parroty/excoveralls) provides test coverage
+  metrics.
 * [credo](https://github.com/rrrene/credo) is used for static code analysis.
+
+
+## License
+
+ExDiceRoller source code is released under Apache 2 License.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,4 @@
 use Mix.Config
+
+config :ex_dice_roller,
+  cache_table: ExDiceRoller.Cache

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -1,6 +1,37 @@
 defmodule ExDiceRoller.Cache do
   @moduledoc """
   Functionality for managing caching for compiled roll functions.
+
+  In many cases, ExDiceRoller can be used to compile a dice roll during project
+  compilation, and using it within its local area, or pass it as an argument
+  elsewhere. However, dice rolls can be generated during runtime. Repeated
+  tokenizing, parsing, and compiling of runtime dice rolls can add up. The more
+  complex the dice roll, the higher the cost.
+
+  Local testing has revealed that there can be a relatively signifcant
+  performance savings by caching compiled dice rolls and reusing the cached
+  values instead of repeated interpretation. While these savings are on the
+  order of microseconds (not milliseconds), they can add up in applications
+  that have complex rules and are regularly generating dice rolls during
+  runtime.
+
+  In an effort to avoid this, ExDiceRoller allows for dice rolls to be cached
+  and reused.
+
+      iex> ExDiceRoller.start_cache()
+      iex> ExDiceRoller.Cache.all()
+      []
+      iex> ExDiceRoller.roll("2d6+1d5", [], [:cache])
+      9
+      iex> [{"2d6+1d5", _}] = ExDiceRoller.Cache.all()
+      iex> ExDiceRoller.roll("2d6+1d5", [], [:cache])
+      11
+      iex> [{"2d6+1d5", _}] = ExDiceRoller.Cache.all()
+      iex> ExDiceRoller.roll("1d4+x", [x: 3], [:cache])
+      7
+      iex> [{"1d4+x", _}, {"2d6+1d5", _}] = ExDiceRoller.Cache.all()
+      iex> ExDiceRoller.roll("1d4+x", [x: 3], [:cache])
+      7
   """
 
   @cache_table Application.fetch_env!(:ex_dice_roller, :cache_table)

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -1,0 +1,96 @@
+defmodule ExDiceRoller.Cache do
+  @moduledoc """
+  Functionality for managing caching for compiled roll functions.
+  """
+
+  @cache_table Application.fetch_env!(:ex_dice_roller, :cache_table)
+
+  @type cache_entry :: {roll_string, roll_fun}
+  @type roll_string :: String.t()
+  @type roll_fun :: function
+
+  @doc """
+  Start the caching system, using the `:ex_dice_roller` config's `:cache_table`
+  value.
+  """
+  @spec start_link() :: {:ok, atom}
+  def start_link, do: start_link(@cache_table)
+
+  @doc "Starts the caching system, using `name` for the cache table."
+  @spec start_link(atom) :: {:ok, atom}
+  def start_link(name) do
+    opts = [:public, :set, :named_table, {:read_concurrency, true}]
+    _ = :ets.new(name, opts)
+    {:ok, name}
+  end
+
+  @doc "Retrieves all cached rolls."
+  @spec all(atom | none) :: list(cache_entry)
+  def all(cache \\ @cache_table), do: :ets.tab2list(cache)
+
+  @doc """
+  Looks up the roll in cache and returns its compiled function. Note that if
+  the roll is not yet cached, it will be compiled, cached, and the compiled
+  function returned.
+  """
+  @spec obtain(atom | none, roll_string) :: roll_fun
+  def obtain(cache \\ @cache_table, roll_string) do
+    case get(cache, roll_string) do
+      {:ok, fun} ->
+        fun
+
+      {:error, :fun_not_found} ->
+        case ExDiceRoller.compile(roll_string) do
+          {:ok, fun} ->
+            :ok = put(cache, roll_string, fun)
+            fun
+
+          {:error, _} = err ->
+            err
+        end
+    end
+  end
+
+  @doc """
+  Creates an entry in cache with `roll_string` as the key and `roll_fun` as the
+  value.
+  """
+  @spec put(atom | none, roll_string, roll_fun) :: :ok
+  def put(cache \\ @cache_table, roll_string, fun) when is_function(fun) do
+    true = :ets.insert(cache, {roll_string, fun})
+    :ok
+  end
+
+  @doc """
+  Deletes the cache entry stored under `roll_string`. Note that if `roll_string`
+  is anything but a string, `{:error, {:invalid_roll_string, roll_string}}`
+  will be returned.
+  """
+  @spec delete(atom | none, roll_string) :: :ok | {:error, {:invalid_roll_string, any}}
+
+  def delete(cache \\ @cache_table, roll_string)
+
+  def delete(cache, roll_string) when is_bitstring(roll_string) do
+    true = :ets.delete(cache, roll_string)
+    :ok
+  end
+
+  def delete(_, roll_string), do: {:error, {:invalid_roll_string, roll_string}}
+
+  @doc """
+  Empties the specified cache.
+  """
+  @spec clear(atom | none) :: :ok
+  def clear(cache \\ @cache_table) do
+    _ = :ets.delete_all_objects(cache)
+    :ok
+  end
+
+  @spec get(atom, String.t()) :: {:ok, roll_fun} | {:error, :fun_not_found}
+  defp get(cache, string) do
+    case :ets.lookup(cache, string) do
+      [{_, fun}] -> {:ok, fun}
+      [] -> {:error, :fun_not_found}
+    end
+  end
+end

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -94,10 +94,10 @@ defmodule ExDiceRoller.Cache do
 
   @doc """
   Deletes the cache entry stored under `roll_string`. Note that if `roll_string`
-  is anything but a string, `{:error, {:invalid_roll_string, roll_string}}`
+  is anything but a string, `{:error, {:invalid_roll_key, roll_string}}`
   will be returned.
   """
-  @spec delete(atom | none, roll_string) :: :ok | {:error, {:invalid_roll_string, any}}
+  @spec delete(atom | none, roll_string) :: :ok | {:error, {:invalid_roll_key, any}}
 
   def delete(cache \\ @cache_table, roll_string)
 
@@ -106,7 +106,7 @@ defmodule ExDiceRoller.Cache do
     :ok
   end
 
-  def delete(_, roll_string), do: {:error, {:invalid_roll_string, roll_string}}
+  def delete(_, roll_string), do: {:error, {:invalid_roll_key, roll_string}}
 
   @doc """
   Empties the specified cache.

--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -4,20 +4,20 @@ defmodule ExDiceRoller.Compiler do
   functions.
 
       > parsed =
-       {{:operator, '+'},
+        {{:operator, '+'},
         {{:operator, '-'}, {:roll, {:digit, '1'}, {:digit, '4'}},
-         {{:operator, '/'}, {:roll, {:digit, '3'}, {:digit, '6'}}, {:digit, '2'}}},
+          {{:operator, '/'}, {:roll, {:digit, '3'}, {:digit, '6'}}, {:digit, '2'}}},
         {:roll, {:roll, {:digit, '1'}, {:digit, '4'}},
-         {:roll, {:digit, '1'}, {:digit, '6'}}}}
+          {:roll, {:digit, '1'}, {:digit, '6'}}}}
 
       > fun = ExDiceRoller.Compiler.compile(parsed)
-      #=> #Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>
+      #Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>
 
       > fun.([], [])
-      #=> 4
+      4
 
       > ExDiceRoller.Compiler.fun_info(fun)
-      #=> {#Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>,
+      {#Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>,
         :"-compile_add/4-fun-0-",
         [
           {#Function<13.47893785/2 in ExDiceRoller.Compiler.compile_sub/4>,
@@ -69,7 +69,7 @@ defmodule ExDiceRoller.Compiler do
       iex> {:ok, parsed} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {{:operator, '+'}, {:roll, {:digit, '1'}, {:digit, '2'}}, {:var, 'x'}}}
       iex> fun = ExDiceRoller.Compiler.compile(parsed)
-      iex> fun.([x: 1], [:cache, :explode])
+      iex> fun.([x: 1], [:explode])
       2
 
   During calculation, float values are left as float for as long as possible.

--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -5,24 +5,20 @@ defmodule ExDiceRoller.Compiler do
   """
 
   alias ExDiceRoller.{Parser, Tokenizer}
-
   @type compiled_val :: compiled_fun | number
-  @type compiled_fun :: (Keyword.t() -> number)
+  @type compiled_fun :: (args, opts -> number)
   @type fun_info_tuple :: {function, atom, list(any)}
+  @type args :: Keyword.t()
+  @type opts :: list(atom | {atom, any})
 
   @doc """
   Compiles a provided `t:Parser.expression/0` into an anonymous function.
 
-  ```elixir
-    {:ok, roll_fun} = ExDiceRoller.compile("1dx+10")
-    {:ok, _}
-
-    ExDiceRoller.execute(roll_fun, x: 5)
-    11
-
-    ExDiceRoller.execute(roll_fun, x: "10d100")
-    523
-  ```
+      iex> {:ok, roll_fun} = ExDiceRoller.compile("1dx+10")
+      iex> ExDiceRoller.execute(roll_fun, x: 5)
+      14
+      iex> ExDiceRoller.execute(roll_fun, x: "10d100")
+      72
   """
   @spec compile(Parser.expression()) :: compiled_val
   def compile({:digit, compiled_val}),
@@ -31,7 +27,6 @@ defmodule ExDiceRoller.Compiler do
   def compile({:roll, left_expr, right_expr}) do
     num = compile(left_expr)
     sides = compile(right_expr)
-
     compile_roll(num, is_function(num), sides, is_function(sides))
   end
 
@@ -47,37 +42,35 @@ defmodule ExDiceRoller.Compiler do
   @doc """
   Shows the nested functions and relationships of a compiled function.
 
-  ```elixir
+      > {:ok, fun} = ExDiceRoller.compile("1d8+(1-x)d(2*y)")
+      #=> {:ok, #Function<0.84780260/1 in ExDiceRoller.Compiler.compile_add/4>}
 
-    > {:ok, fun} = ExDiceRoller.compile("1d8+(1-x)d(2*y)")
-    {:ok, #Function<0.84780260/1 in ExDiceRoller.Compiler.compile_add/4>}
-
-    > ExDiceRoller.Compiler.fun_info fun
-    {#Function<0.16543174/1 in ExDiceRoller.Compiler.compile_add/4>,
-    :"-compile_add/4-fun-0-",
-    [
-      {#Function<12.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
-        :"-compile_roll/4-fun-3-", [1, 8]},
-      {#Function<9.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
-        :"-compile_roll/4-fun-0-",
-        [
-          {#Function<15.16543174/1 in ExDiceRoller.Compiler.compile_sub/4>,
-          :"-compile_sub/4-fun-2-",
+      > ExDiceRoller.Compiler.fun_info fun
+      #=> {#Function<0.16543174/1 in ExDiceRoller.Compiler.compile_add/4>,
+      :"-compile_add/4-fun-0-",
+      [
+        {#Function<12.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
+          :"-compile_roll/4-fun-3-", [1, 8]},
+        {#Function<9.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
+          :"-compile_roll/4-fun-0-",
           [
-            1,
-            {#Function<16.16543174/1 in ExDiceRoller.Compiler.compile_var/1>,
-              :"-compile_var/1-fun-0-", ['x']}
-          ]},
-          {#Function<8.16543174/1 in ExDiceRoller.Compiler.compile_mul/4>,
-          :"-compile_mul/4-fun-2-",
-          [
-            2,
-            {#Function<16.16543174/1 in ExDiceRoller.Compiler.compile_var/1>,
-              :"-compile_var/1-fun-0-", ['y']}
+            {#Function<15.16543174/1 in ExDiceRoller.Compiler.compile_sub/4>,
+            :"-compile_sub/4-fun-2-",
+            [
+              1,
+              {#Function<16.16543174/1 in ExDiceRoller.Compiler.compile_var/1>,
+                :"-compile_var/1-fun-0-", ['x']}
+            ]},
+            {#Function<8.16543174/1 in ExDiceRoller.Compiler.compile_mul/4>,
+            :"-compile_mul/4-fun-2-",
+            [
+              2,
+              {#Function<16.16543174/1 in ExDiceRoller.Compiler.compile_var/1>,
+                :"-compile_var/1-fun-0-", ['y']}
+            ]}
           ]}
-        ]}
-    ]}
-  ```
+      ]}
+
   """
   @spec fun_info(compiled_fun) :: fun_info_tuple
   def fun_info(fun) when is_function(fun) do
@@ -96,25 +89,50 @@ defmodule ExDiceRoller.Compiler do
 
   @spec compile_roll(compiled_val, boolean, compiled_val, boolean) :: compiled_fun
   defp compile_roll(num, true, sides, true) do
-    fn args -> roll_final(num.(args), sides.(args)) end
+    fn args, opts -> roll_final(num.(args, opts), sides.(args, opts), opts) end
   end
 
-  defp compile_roll(num, true, sides, false), do: fn args -> roll_final(num.(args), sides) end
-  defp compile_roll(num, false, sides, true), do: fn args -> roll_final(num, sides.(args)) end
-  defp compile_roll(num, false, sides, false), do: fn _args -> roll_final(num, sides) end
+  defp compile_roll(num, true, sides, false),
+    do: fn args, opts -> roll_final(num.(args, opts), sides, opts) end
 
-  @spec roll_final(number, number) :: integer
-  defp roll_final(0, _), do: 0
-  defp roll_final(_, 0), do: 0
+  defp compile_roll(num, false, sides, true),
+    do: fn args, opts -> roll_final(num, sides.(args, opts), opts) end
 
-  defp roll_final(num, sides) when num >= 0 and sides >= 0 do
+  defp compile_roll(num, false, sides, false),
+    do: fn _args, opts -> roll_final(num, sides, opts) end
+
+  @spec roll_final(number, number, list(atom | tuple)) :: integer
+  defp roll_final(0, _, _), do: 0
+  defp roll_final(_, 0, _), do: 0
+
+  defp roll_final(num, sides, opts) when num >= 0 and sides >= 0 do
     num = round(num)
     sides = round(sides)
-    Enum.reduce(1..num, 0, fn _, total -> Enum.random(1..sides) + total end)
+    explode? = :explode in opts
+
+    Enum.reduce(1..num, 0, fn _, total ->
+      total + roll(sides, explode?)
+    end)
   end
 
-  defp roll_final(_, _),
+  defp roll_final(_, _, _),
     do: raise(ArgumentError, "neither number of dice nor number of sides cannot be less than 0")
+
+  defp roll(sides, false) do
+    Enum.random(1..sides)
+  end
+
+  defp roll(sides, true) do
+    result = Enum.random(1..sides)
+    explode_roll(sides, result, result)
+  end
+
+  defp explode_roll(sides, sides, acc) do
+    result = Enum.random(1..sides)
+    explode_roll(sides, result, acc + result)
+  end
+
+  defp explode_roll(_, _, acc), do: acc
 
   @spec compile_op(list, compiled_val, boolean, compiled_val, boolean) :: compiled_val
   defp compile_op('+', l, l_fun?, r, r_fun?), do: compile_add(l, l_fun?, r, r_fun?)
@@ -123,34 +141,34 @@ defmodule ExDiceRoller.Compiler do
   defp compile_op('/', l, l_fun?, r, r_fun?), do: compile_div(l, l_fun?, r, r_fun?)
 
   @spec compile_add(compiled_val, boolean, compiled_val, boolean) :: compiled_val
-  defp compile_add(l, true, r, true), do: fn args -> l.(args) + r.(args) end
-  defp compile_add(l, true, r, false), do: fn args -> l.(args) + r end
-  defp compile_add(l, false, r, true), do: fn args -> l + r.(args) end
+  defp compile_add(l, true, r, true), do: fn args, opts -> l.(args, opts) + r.(args, opts) end
+  defp compile_add(l, true, r, false), do: fn args, opts -> l.(args, opts) + r end
+  defp compile_add(l, false, r, true), do: fn args, opts -> l + r.(args, opts) end
   defp compile_add(l, false, r, false), do: l + r
 
   @spec compile_sub(compiled_val, boolean, compiled_val, boolean) :: compiled_val
-  defp compile_sub(l, true, r, true), do: fn args -> l.(args) - r.(args) end
-  defp compile_sub(l, true, r, false), do: fn args -> l.(args) - r end
-  defp compile_sub(l, false, r, true), do: fn args -> l - r.(args) end
+  defp compile_sub(l, true, r, true), do: fn args, opts -> l.(args, opts) - r.(args, opts) end
+  defp compile_sub(l, true, r, false), do: fn args, opts -> l.(args, opts) - r end
+  defp compile_sub(l, false, r, true), do: fn args, opts -> l - r.(args, opts) end
   defp compile_sub(l, false, r, false), do: l - r
 
   @spec compile_mul(compiled_val, boolean, compiled_val, boolean) :: compiled_val
-  defp compile_mul(l, true, r, true), do: fn args -> l.(args) * r.(args) end
-  defp compile_mul(l, true, r, false), do: fn args -> l.(args) * r end
-  defp compile_mul(l, false, r, true), do: fn args -> l * r.(args) end
+  defp compile_mul(l, true, r, true), do: fn args, opts -> l.(args, opts) * r.(args, opts) end
+  defp compile_mul(l, true, r, false), do: fn args, opts -> l.(args, opts) * r end
+  defp compile_mul(l, false, r, true), do: fn args, opts -> l * r.(args, opts) end
   defp compile_mul(l, false, r, false), do: l * r
 
   @spec compile_div(compiled_val, boolean, compiled_val, boolean) :: compiled_val
-  defp compile_div(l, true, r, true), do: fn args -> l.(args) / r.(args) end
-  defp compile_div(l, true, r, false), do: fn args -> l.(args) / r end
-  defp compile_div(l, false, r, true), do: fn args -> l / r.(args) end
+  defp compile_div(l, true, r, true), do: fn args, opts -> l.(args, opts) / r.(args, opts) end
+  defp compile_div(l, true, r, false), do: fn args, opts -> l.(args, opts) / r end
+  defp compile_div(l, false, r, true), do: fn args, opts -> l / r.(args, opts) end
   defp compile_div(l, false, r, false), do: l / r
 
   @spec compile_var({:var, charlist}) :: compiled_fun
-  defp compile_var({:var, var}), do: fn args -> var_final(var, args) end
+  defp compile_var({:var, var}), do: fn args, opts -> var_final(var, args, opts) end
 
-  @spec var_final(charlist, Keyword.t()) :: number
-  defp var_final(var, args) do
+  @spec var_final(charlist, Keyword.t(), list(atom | tuple)) :: number
+  defp var_final(var, args, _opts) do
     key = var |> to_string() |> String.to_atom()
 
     case Keyword.get(args, key) do
@@ -167,7 +185,7 @@ defmodule ExDiceRoller.Compiler do
 
         case is_function(maybe_fun) do
           false -> maybe_fun
-          true -> maybe_fun.([])
+          true -> maybe_fun.([], [])
         end
     end
   end

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -26,8 +26,13 @@ defmodule ExDiceRoller do
       iex> ExDiceRoller.roll("1+\t2*3d 4")
       15
 
-      iex> ExDiceRoller.roll("1dx+6", x: 10)
-      15
+      iex> ExDiceRoller.roll("1dx+6-y", x: 10, y: 5)
+      10
+
+      iex> ExDiceRoller.roll("1d2", [], [:explode])
+      1
+      iex> ExDiceRoller.roll("1d2", [], [:explode])
+      7
 
   ## Order of Precedence
 
@@ -93,23 +98,65 @@ defmodule ExDiceRoller do
       10
       iex> ExDiceRoller.execute(roll_fun)
       11
+
   """
 
-  alias ExDiceRoller.{Compiler, Parser, Tokenizer}
+  alias ExDiceRoller.{Cache, Compiler, Parser, Tokenizer}
+
+  @cache_table Application.fetch_env!(:ex_dice_roller, :cache_table)
 
   @doc """
-  Processes a given string as a dice roll and returns the final result. Note
-  that the final result is a rounded integer.
+  Processes a given string as a dice roll and returns the final result. The
+  final result is a rounded integer.
 
       iex> ExDiceRoller.roll("1d6+15")
       18
+
+
+  Note that using variables with this call will result in errors. If you need
+  variables, use `roll/3` instead.
   """
-  @spec roll(String.t(), Keyword.t()) :: integer
-  def roll(roll_string, args \\ []) do
+  @spec roll(String.t()) :: integer
+  def roll(roll_string), do: roll(roll_string, [], [])
+
+  @doc """
+  Processes a given string as a dice roll and returns the final result. The
+  final result is a rounded integer.
+
+  Any variables should be specified in `args`. Options can be passed in `opts`.
+
+  Possible options include:
+  * `:cache`: This will add compiled function caching. Refer to
+  `ExDiceRoller.Cache.obtain/2` for more information.
+
+  ### Examples
+
+      iex> ExDiceRoller.roll("1d6+15", [])
+      18
+
+      iex> ExDiceRoller.roll("1d8+x", x: 5)
+      6
+
+      iex> ExDiceRoller.start_cache(ExDiceRoller.Cache)
+      iex> ExDiceRoller.roll("(1d6)d4-3+y", [y: 3], [:cache])
+      10
+
+  """
+  @spec roll(String.t(), Keyword.t(), list(atom | tuple)) :: integer
+
+  def roll(roll_string, args, opts \\ [])
+
+  def roll(roll_string, args, [:cache | rest]) do
+    @cache_table
+    |> Cache.obtain(roll_string)
+    |> execute(args, rest)
+  end
+
+  def roll(roll_string, args, opts) do
     with {:ok, tokens} <- Tokenizer.tokenize(roll_string),
          {:ok, parsed_tokens} <- Parser.parse(tokens) do
       parsed_tokens
-      |> calculate(args)
+      |> calculate(args, opts)
       |> round()
     else
       {:error, _} = err -> err
@@ -127,12 +174,12 @@ defmodule ExDiceRoller do
   @doc """
   Takes a given expression from parse and calculates the result.
   """
-  @spec calculate(Parser.expression(), Keyword.t()) :: number
-  def calculate(expression, args \\ []) do
+  @spec calculate(Parser.expression(), Compiler.args(), Compiler.opts()) :: number
+  def calculate(expression, args \\ [], opts \\ []) do
     expression
     |> compile()
     |> elem(1)
-    |> execute(args)
+    |> execute(args, opts)
   end
 
   @doc """
@@ -141,9 +188,12 @@ defmodule ExDiceRoller do
       iex> {:ok, roll_fun} = ExDiceRoller.compile("1d8+2d(5d3+4)/3")
       iex> ExDiceRoller.execute(roll_fun)
       5.0
+
   """
   @spec compile(String.t() | Parser.expression()) ::
           {:ok, Compiler.compiled_function()} | {:error, any}
+  def compile(roll)
+
   def compile(roll_string) when is_bitstring(roll_string) do
     with {:ok, tokens} <- Tokenizer.tokenize(roll_string),
          {:ok, parsed_tokens} <- Parser.parse(tokens) do
@@ -157,14 +207,25 @@ defmodule ExDiceRoller do
     compiled = Compiler.compile(expression)
 
     case is_function(compiled) do
-      false -> {:ok, fn _args -> compiled end}
+      false -> {:ok, fn _args, _opts -> compiled end}
       true -> {:ok, compiled}
     end
   end
 
+  def compile(other), do: {:error, {:invalid_roll_string, other}}
+
   @doc "Executes a function built by `compile/1`."
-  @spec execute(function, Keyword.t()) :: number
-  def execute(compiled, args \\ []) when is_function(compiled) do
-    compiled.(args)
+  @spec execute(function, Compiler.args(), Compiler.opts()) :: number
+  def execute(compiled, args \\ [], opts \\ []) when is_function(compiled) do
+    compiled.(args, opts)
+  end
+
+  @doc """
+  Starts the underlying roll function cache. See `ExDiceRoller.Cache` for more
+  details.
+  """
+  @spec start_cache(atom | none) :: {:ok, any}
+  def start_cache(cache \\ @cache_table) do
+    {:ok, _} = Cache.start_link(cache)
   end
 end

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -102,6 +102,7 @@ defmodule ExDiceRoller do
       22
       ```
 
+
   ## Caching
 
   ExDiceRoller can cache and reuse dice rolls.
@@ -117,6 +118,22 @@ defmodule ExDiceRoller do
       6
 
   More details can be found in the documentation for `ExDiceRoller.Cache`.
+
+
+  ## Sigil Support
+
+  ExDiceRoller comes with its own sigil, `~a`, that can be used to create
+  compiled dice roll functions or roll them on the spot. See
+  `ExDiceRoller.Sigil` for detailed usage and examples.
+
+      iex> import ExDiceRoller.Sigil
+      iex> fun = ~a/2d6+2/
+      iex> ExDiceRoller.roll(fun)
+      7
+      iex> ExDiceRoller.roll(~a|1d4+x/5|, [x: 43])
+      11
+      iex> ExDiceRoller.roll(~a|xdy|, [x: fun, y: ~a/12d4-15/])
+      111
 
 
   ## ExDiceRoller Examples
@@ -166,7 +183,7 @@ defmodule ExDiceRoller do
       10
 
       iex> import ExDiceRoller.Sigil
-      iex> ~a/1d2+3/r #
+      iex> ~a/1d2+3/r
       4
       iex> ~a/1d2+2/re
       9

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -1,5 +1,46 @@
 defmodule ExDiceRoller.Parser do
-  @moduledoc "Functionality for parsing `t:ExDiceRoller.Tokenizer.tokens/0`."
+  @moduledoc """
+  Functionality for parsing `t:ExDiceRoller.Tokenizer.tokens/0`.
+
+      iex> {:ok, tokens} = ExDiceRoller.Tokenizer.tokenize("2d3+9-(ydz)d(31+x)/(3d8+2)")
+      {:ok,
+      [
+        {:digit, 1, '2'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '3'},
+        {:basic_operator, 1, '+'},
+        {:digit, 1, '9'},
+        {:basic_operator, 1, '-'},
+        {:"(", 1, '('},
+        {:var, 1, 'y'},
+        {:roll, 1, 'd'},
+        {:var, 1, 'z'},
+        {:")", 1, ')'},
+        {:roll, 1, 'd'},
+        {:"(", 1, '('},
+        {:digit, 1, '31'},
+        {:basic_operator, 1, '+'},
+        {:var, 1, 'x'},
+        {:")", 1, ')'},
+        {:complex_operator, 1, '/'},
+        {:"(", 1, '('},
+        {:digit, 1, '3'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '8'},
+        {:basic_operator, 1, '+'},
+        {:digit, 1, '2'},
+        {:")", 1, ')'}
+      ]}
+      iex> ExDiceRoller.Parser.parse(tokens)
+      {:ok,
+      {{:operator, '-'},
+        {{:operator, '+'}, {:roll, {:digit, '2'}, {:digit, '3'}}, {:digit, '9'}},
+        {{:operator, '/'},
+        {:roll, {:roll, {:var, 'y'}, {:var, 'z'}},
+          {{:operator, '+'}, {:digit, '31'}, {:var, 'x'}}},
+        {{:operator, '+'}, {:roll, {:digit, '3'}, {:digit, '8'}}, {:digit, '2'}}}}}
+
+  """
 
   alias ExDiceRoller.Tokenizer
 

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -1,0 +1,65 @@
+defmodule ExDiceRoller.Sigil do
+  @moduledoc """
+    Handles the sigil `~a` for dice rolling. If no options are specified, the
+  sigil will return the compiled function based on the provided roll.
+
+  The following options are available:
+
+  * `r`: Compiles and executes the roll. Variables are not supported with this.
+  * `e`: Allows dice to explode. Can only be used if used alongside option `r`.
+
+  ## Example
+
+      iex> import ExDiceRoller.Sigil
+      ExDiceRoller.Sigil
+      iex> fun = ~a/1+1/
+      iex> fun.([], [])
+      2
+
+      iex> import ExDiceRoller.Sigil
+      iex> fun = ~a/1d4/
+      iex> fun.([], [])
+      1
+      iex> fun.([], [])
+      4
+
+      iex> import ExDiceRoller.Sigil
+      iex> ~a/1d6+1/r
+      4
+      iex> ~a/1d2/re
+      7
+
+      iex> import ExDiceRoller.Sigil
+      iex> ~a/1d2/e
+      {:error, :explode_allowed_only_with_roll}
+
+  """
+
+  @spec sigil_a(String.t(), charlist) :: function | integer | float
+
+  def sigil_a(_, [mod]) when mod == ?e, do: {:error, :explode_allowed_only_with_roll}
+
+  def sigil_a(roll_string, opts) do
+    binary_opts = :binary.list_to_bin(opts)
+
+    with {:ok, translated_opts} <- translate_opts(binary_opts, []),
+         {:ok, fun} = ExDiceRoller.compile(roll_string) do
+      case :execute in translated_opts do
+        false ->
+          {:ok, fun} = ExDiceRoller.compile(roll_string)
+          fun
+
+        true ->
+          fun.([], translated_opts -- [:execute])
+      end
+    else
+      {:error, rest} -> {:error, {:invalid_option, rest}}
+    end
+  end
+
+  @spec translate_opts(binary, list(atom)) :: {:ok, list(atom)} | {:error, any}
+  defp translate_opts(<<?r, t::binary>>, acc), do: translate_opts(t, [:execute | acc])
+  defp translate_opts(<<?e, t::binary>>, acc), do: translate_opts(t, [:explode | acc])
+  defp translate_opts(<<>>, acc), do: {:ok, acc}
+  defp translate_opts(rest, _acc), do: {:error, rest}
+end

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -1,12 +1,12 @@
 defmodule ExDiceRoller.Sigil do
   @moduledoc """
-    Handles the sigil `~a` for dice rolling. If no options are specified, the
+  Han dles the sigil `~a` for dice rolling. If no options are specified, the
   sigil will return the compiled function based on the provided roll.
 
   The following options are available:
 
-  * `r`: Compiles and executes the roll. Variables are not supported with this.
-  * `e`: Allows dice to explode. Can only be used if used alongside option `r`.
+  * `r`: Compiles and invokes the roll. Variables are not supported with this.
+  * `e`: Allows dice to explode. Can only be used alongside option `r`.
 
   ## Example
 

--- a/lib/tokenizer.ex
+++ b/lib/tokenizer.ex
@@ -1,5 +1,37 @@
 defmodule ExDiceRoller.Tokenizer do
-  @moduledoc "Provides functionality around tokenizing dice roll strings."
+  @moduledoc """
+  Provides functionality around tokenizing dice roll strings.
+
+      iex> ExDiceRoller.Tokenizer.tokenize("1d4+6-(2dy)d(5*2d7-x)/3d8")
+      {:ok,
+      [
+        {:digit, 1, '1'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '4'},
+        {:basic_operator, 1, '+'},
+        {:digit, 1, '6'},
+        {:basic_operator, 1, '-'},
+        {:"(", 1, '('},
+        {:digit, 1, '2'},
+        {:roll, 1, 'd'},
+        {:var, 1, 'y'},
+        {:")", 1, ')'},
+        {:roll, 1, 'd'},
+        {:"(", 1, '('},
+        {:digit, 1, '5'},
+        {:complex_operator, 1, '*'},
+        {:digit, 1, '2'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '7'},
+        {:basic_operator, 1, '-'},
+        {:var, 1, 'x'},
+        {:")", 1, ')'},
+        {:complex_operator, 1, '/'},
+        {:digit, 1, '3'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '8'}
+      ]}
+  """
 
   @type tokens :: [token, ...]
   @type token :: {token_type, integer, list}

--- a/test/cache_test.exs
+++ b/test/cache_test.exs
@@ -95,7 +95,7 @@ defmodule ExDiceRoller.CacheTest do
   test "delete errors with bad rollstring" do
     {:ok, CacheTest} = Cache.start_link(CacheTest)
 
-    {:error, {:invalid_roll_string, :not_a_roll_string}} =
+    {:error, {:invalid_roll_key, :not_a_roll_string}} =
       Cache.delete(CacheTest, :not_a_roll_string)
   end
 end

--- a/test/cache_test.exs
+++ b/test/cache_test.exs
@@ -1,0 +1,95 @@
+defmodule ExDiceRoller.CacheTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  alias ExDiceRoller.Cache
+
+  test "starting with no name" do
+    cache = Application.fetch_env!(:ex_dice_roller, :cache_table)
+    {:ok, ^cache} = Cache.start_link()
+  end
+
+  test "starting with name" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+  end
+
+  test "put" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    roll_1 = "1d6"
+    {:ok, fun_1} = ExDiceRoller.compile(roll_1)
+    :ok = Cache.put(CacheTest, roll_1, fun_1)
+    ^fun_1 = Cache.obtain(CacheTest, roll_1)
+  end
+
+  test "obtain" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    fun = Cache.obtain(CacheTest, "1d6")
+    assert is_function(fun)
+  end
+
+  test "errors on obtain" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    {:error, _} = Cache.obtain(CacheTest, "1&")
+    {:error, _} = Cache.obtain(CacheTest, :not_a_string)
+  end
+
+  test "all" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    roll_1 = "1d6"
+    roll_2 = "1d8+10-5d8"
+    fun_1 = Cache.obtain(CacheTest, roll_1)
+    fun_2 = Cache.obtain(CacheTest, roll_2)
+    ^fun_1 = Cache.obtain(CacheTest, roll_1)
+
+    funs = Cache.all(CacheTest)
+    assert length(funs) == 2
+    assert {^roll_1, ^fun_1} = Enum.find(funs, &(roll_1 == elem(&1, 0)))
+    assert {^roll_2, ^fun_2} = Enum.find(funs, &(roll_2 == elem(&1, 0)))
+  end
+
+  test "clear" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    _ = Cache.obtain(CacheTest, "1d6")
+    _ = Cache.obtain(CacheTest, "1d8+10-5d8")
+
+    assert 2 == CacheTest |> Cache.all() |> length()
+    :ok = Cache.clear(CacheTest)
+    assert 0 == CacheTest |> Cache.all() |> length()
+  end
+
+  test "delete" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+    roll_1 = "1d6"
+    roll_2 = "1d4+110-5d8 + 1d4/5"
+    _ = Cache.obtain(CacheTest, roll_1)
+    _ = Cache.obtain(CacheTest, roll_2)
+
+    assert 2 == CacheTest |> Cache.all() |> length()
+    :ok = Cache.delete(CacheTest, roll_1)
+    assert 1 == CacheTest |> Cache.all() |> length()
+    _ = Cache.obtain(CacheTest, roll_1)
+    assert 2 == CacheTest |> Cache.all() |> length()
+  end
+
+  test "delete with no cache named" do
+    {:ok, Cache} = Cache.start_link()
+    roll_1 = "1d6"
+    roll_2 = "1d4+110-5d8 + 1d4/5"
+    _ = Cache.obtain(roll_1)
+    _ = Cache.obtain(roll_2)
+
+    assert 2 == Cache.all() |> length()
+    :ok = Cache.delete(roll_1)
+    assert 1 == Cache.all() |> length()
+    _ = Cache.obtain(roll_1)
+    assert 2 == Cache.all() |> length()
+  end
+
+  test "delete errors with bad rollstring" do
+    {:ok, CacheTest} = Cache.start_link(CacheTest)
+
+    {:error, {:invalid_roll_string, :not_a_roll_string}} =
+      Cache.delete(CacheTest, :not_a_roll_string)
+  end
+end

--- a/test/cache_test.exs
+++ b/test/cache_test.exs
@@ -2,8 +2,14 @@ defmodule ExDiceRoller.CacheTest do
   @moduledoc false
 
   use ExUnit.Case
+  doctest ExDiceRoller.Cache
 
   alias ExDiceRoller.Cache
+
+  setup do
+    :rand.seed(:exsplus, {5, 7, 13})
+    :ok
+  end
 
   test "starting with no name" do
     cache = Application.fetch_env!(:ex_dice_roller, :cache_table)

--- a/test/sigil_test.exs
+++ b/test/sigil_test.exs
@@ -1,0 +1,84 @@
+defmodule ExDiceRoller.SigilTest do
+  @moduledoc false
+
+  use ExUnit.Case
+  doctest ExDiceRoller.Sigil
+  import ExDiceRoller.Sigil
+  alias ExDiceRoller.Cache
+
+  setup do
+    # This is called to make doctests predictable.
+    :rand.seed(:exsplus, {5, 7, 13})
+    {:ok, _} = Cache.start_link()
+    :ok
+  end
+
+  describe "using no options" do
+    test "basic" do
+      fun = ~a/1+1/
+      assert is_function(fun)
+      assert 2 == ExDiceRoller.execute(fun)
+    end
+
+    test "rolls" do
+      fun = ~a/1d20/
+      assert is_function(fun)
+      assert 9 == ExDiceRoller.execute(fun)
+    end
+
+    test "complex" do
+      fun = ~a|1d20+(2d4)d(3d10)/5|
+      assert is_function(fun)
+      assert 17.2 == ExDiceRoller.execute(fun)
+    end
+
+    test "variables" do
+      fun = ~a/3d6+x-y/
+      assert is_function(fun)
+      assert 14 == ExDiceRoller.execute(fun, x: 5, y: 2)
+    end
+
+    test "errors when using variables but missing values" do
+      fun = ~a/3d6+x-y/
+      assert is_function(fun)
+
+      assert_raise(ArgumentError, "no variable 'x' was found in the arguments", fn ->
+        ExDiceRoller.execute(fun)
+      end)
+
+      assert_raise(ArgumentError, "no variable 'y' was found in the arguments", fn ->
+        ExDiceRoller.execute(fun, x: 5)
+      end)
+
+      assert_raise(ArgumentError, "no variable 'x' was found in the arguments", fn ->
+        ExDiceRoller.execute(fun, y: 2)
+      end)
+    end
+  end
+
+  describe "executing rolls with option `r`" do
+    test "basic" do
+      assert 2 == ~a/1+1/r
+    end
+
+    test "roll" do
+      assert 12 == ~a/1d10+3/r
+    end
+
+    test "complex" do
+      assert 27.25 == ~a|1d(5d4+3)+(2d6)d(5d4)/4-2|r
+    end
+
+    test "with exploding dice" do
+      assert 5 = ~a/1d3/re
+      assert 4 = ~a/1d3/re
+      assert 2 = ~a/1d3/re
+    end
+
+    test "fails when using variables" do
+      assert_raise(ArgumentError, "no variable 'b' was found in the arguments", fn ->
+        ~a/1d4+b/r
+      end)
+    end
+  end
+end

--- a/test/sigil_test.exs
+++ b/test/sigil_test.exs
@@ -29,7 +29,7 @@ defmodule ExDiceRoller.SigilTest do
     test "complex" do
       fun = ~a|1d20+(2d4)d(3d10)/5|
       assert is_function(fun)
-      assert 17.2 == ExDiceRoller.execute(fun)
+      assert 17 == ExDiceRoller.execute(fun)
     end
 
     test "variables" do
@@ -66,7 +66,7 @@ defmodule ExDiceRoller.SigilTest do
     end
 
     test "complex" do
-      assert 27.25 == ~a|1d(5d4+3)+(2d6)d(5d4)/4-2|r
+      assert 27 == ~a|1d(5d4+3)+(2d6)d(5d4)/4-2|r
     end
 
     test "with exploding dice" do


### PR DESCRIPTION
**Features**
- added a new sigil `~a` in `ExDiceRoller.Sigil` for compiling functions and/or performing rolls
- added exploding dice logic to the dice roller and sigil
- added optional caching support `ExDiceRoller.Cache` for compiled dice rolls generated during runtime
- added `ExDiceRoller.Compiler.fun_info/1` to inspect the compiled function hierarchy, closure values, and relationships of a compiled dice roll

**Fixes**
- dice roll invocations now consistently return integers as the final value, instead of `ExDiceRoller.execute/3` potentially returning a float
- compiled functions can now be passed as values for variables

**Other**
- a significant increase in documentation and doctests, which led to further minor fixes/adjustments
