### PR TITLE
Feature/high low of rolls

### DIFF
--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -106,8 +106,13 @@ defmodule ExDiceRoller.Compiler do
   defp do_compile({{:operator, op}, left_expr, right_expr}) do
     left_expr = do_compile(left_expr)
     right_expr = do_compile(right_expr)
-
     compile_op(op, left_expr, is_function(left_expr), right_expr, is_function(right_expr))
+  end
+
+  defp do_compile({:sep, left_expr, right_expr}) do
+    left_expr = do_compile(left_expr)
+    right_expr = do_compile(right_expr)
+    compile_sep(left_expr, is_function(left_expr), right_expr, is_function(right_expr))
   end
 
   defp do_compile({:var, _} = var), do: compile_var(var)
@@ -169,6 +174,7 @@ defmodule ExDiceRoller.Compiler do
   defp do_fun_info(str) when is_list(str), do: str
 
   @spec compile_roll(compiled_val, boolean, compiled_val, boolean) :: compiled_fun
+
   defp compile_roll(num, true, sides, true) do
     fn args, opts -> roll_final(num.(args, opts), sides.(args, opts), opts) end
   end
@@ -244,6 +250,33 @@ defmodule ExDiceRoller.Compiler do
   defp compile_div(l, true, r, false), do: fn args, opts -> l.(args, opts) / r end
   defp compile_div(l, false, r, true), do: fn args, opts -> l / r.(args, opts) end
   defp compile_div(l, false, r, false), do: l / r
+
+  @spec compile_sep(compiled_val, boolean, compiled_val, boolean) :: compiled_val
+  defp compile_sep(l, true, r, true),
+    do: fn args, opts -> choose_high_low(l.(args, opts), r.(args, opts), opts) end
+
+  defp compile_sep(l, true, r, false),
+    do: fn args, opts -> choose_high_low(l.(args, opts), r, opts) end
+
+  defp compile_sep(l, false, r, true),
+    do: fn args, opts -> choose_high_low(l, r.(args, opts), opts) end
+
+  defp compile_sep(l, false, r, false), do: fn _args, opts -> choose_high_low(l, r, opts) end
+
+  defp choose_high_low(l, l, _), do: l
+
+  defp choose_high_low(l, r, opts) when is_list(opts) do
+    case Enum.find(opts, &(&1 in [:highest, :lowest])) do
+      :highest -> choose_high_low(l, r, :highest)
+      :lowest -> choose_high_low(l, r, :lowest)
+      _ -> choose_high_low(l, r, :highest)
+    end
+  end
+
+  defp choose_high_low(l, r, :highest) when l > r, do: l
+  defp choose_high_low(_, r, :highest), do: r
+  defp choose_high_low(l, r, :lowest) when l < r, do: l
+  defp choose_high_low(_, r, :lowest), do: r
 
   @spec compile_var({:var, charlist}) :: compiled_fun
   defp compile_var({:var, var}), do: fn args, opts -> var_final(var, args, opts) end

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -23,8 +23,9 @@ defmodule ExDiceRoller do
   --------------------- | ------------
   `d`                   | left-to-right
   `+`, `-`              | unary
-  `*`, `/`              | left-to-right
+  `*`, `/`, `%`, `^`    | left-to-right
   `+`, `-`              | left-to-right
+  `,`                   | left-to-right
 
   ### Effects of Parentheses
 

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -247,6 +247,11 @@ defmodule ExDiceRoller do
       iex> ExDiceRoller.roll("1d2+y", [y: 2], [:cache, :explode])
       11
 
+      iex> ExDiceRoller.roll("1,2", [], [:highest])
+      2
+      iex> ExDiceRoller.roll("10,12,45,3,100", [], [:lowest])
+      3
+
   """
   @spec roll(String.t() | Compiler.compiled_fun(), Keyword.t(), list(atom | tuple)) :: integer
 

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -224,6 +224,10 @@ defmodule ExDiceRoller do
   in the highest possible value for a die (such as rolling a 20 on a d20), the
   die will be rerolled until the result is no longer the max possible. It then
   sums the total of all rolls and returns that value.
+  * `:highest`: Selects the highest of all calculated values when using the `,`
+  operator.
+  * `:lowest`: Selects the lowest of all calculated values when using the `,`
+  operator.
 
   ### Examples
 

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -7,6 +7,8 @@ defmodule ExDiceRoller.Sigil do
 
   * `r`: Compiles and invokes the roll. Variables are not supported with this.
   * `e`: Allows dice to explode. Can only be used alongside option `r`.
+  * `h`: If the dice roll contains any separators `,`, select the highest of the calculated values. Can only be used alongside option `r`.
+  * `l`: If the dice roll contains any separators `,`, select the lowest of the calculated values. Can only be used alongside option `r`.
 
   ## Example
 
@@ -60,6 +62,8 @@ defmodule ExDiceRoller.Sigil do
   @spec translate_opts(binary, list(atom)) :: {:ok, list(atom)} | {:error, any}
   defp translate_opts(<<?r, t::binary>>, acc), do: translate_opts(t, [:execute | acc])
   defp translate_opts(<<?e, t::binary>>, acc), do: translate_opts(t, [:explode | acc])
+  defp translate_opts(<<?h, t::binary>>, acc), do: translate_opts(t, [:highest | acc])
+  defp translate_opts(<<?l, t::binary>>, acc), do: translate_opts(t, [:lowest | acc])
   defp translate_opts(<<>>, acc), do: {:ok, acc}
   defp translate_opts(rest, _acc), do: {:error, rest}
 end

--- a/src/dice_lexer.xrl
+++ b/src/dice_lexer.xrl
@@ -8,6 +8,7 @@ Space           = [\s\t\n\r]+
 LeftParen       = \(
 RightParen      = \)
 Variable        = [a-zA-Z]
+Separator       = ,
 
 Rules.
 
@@ -19,5 +20,6 @@ Rules.
 {RightParen}        : {token, {')', TokenLine, TokenChars}}.
 {Number}            : {token, {digit, TokenLine, TokenChars}}.
 {Variable}          : {token, {var, TokenLine, TokenChars}}.
+{Separator}         : {token, {',', TokenLine, TokenChars}}.
 
 Erlang code.

--- a/src/dice_parser.yrl
+++ b/src/dice_parser.yrl
@@ -8,6 +8,7 @@ var
 digit
 basic_operator
 complex_operator
+','
 roll
 '('
 ')'
@@ -20,6 +21,7 @@ Left 400 unary_operator.
 Left 300 complex_operator.
 Left 200 basic_operator.
 
+expr -> expr ',' expr               : {sep, '$1', '$3'}.
 expr -> expr roll expr              : {roll, '$1', '$3'}.
 expr -> expr complex_operator expr  : {op('$2'), '$1', '$3'}.
 expr -> expr basic_operator expr    : {op('$2'), '$1', '$3'}.

--- a/test/ex_dice_roller_test.exs
+++ b/test/ex_dice_roller_test.exs
@@ -24,6 +24,10 @@ defmodule ExDiceRollerTest do
       1 = ExDiceRoller.roll("1d4")
       8 = ExDiceRoller.roll("2d6")
       6 = ExDiceRoller.roll("1d12+2")
+      2 = ExDiceRoller.roll("1,2")
+      3 = ExDiceRoller.roll("3,3")
+      83 = ExDiceRoller.roll("11,5,83,42,36")
+      1 = ExDiceRoller.roll("2,1", [], [:lowest])
     end
 
     test "unary" do
@@ -49,6 +53,8 @@ defmodule ExDiceRollerTest do
       -24 = ExDiceRoller.roll("1d7d(9/8)+(5-6d8)")
       1 = ExDiceRoller.roll("1d8+(-3/2)")
       3 = ExDiceRoller.roll("-3/2+2d4")
+      6 = ExDiceRoller.roll("4d1, 6d1")
+      15 = ExDiceRoller.roll("3d6+9,1d4")
     end
 
     test "variations of expressions" do
@@ -61,6 +67,9 @@ defmodule ExDiceRollerTest do
       -3 = ExDiceRoller.roll("1d4 - 4")
       6 = ExDiceRoller.roll("1d4 * 2")
       1 = ExDiceRoller.roll("1d4 / 3")
+      4 = ExDiceRoller.roll("4d1, 3")
+      3 = ExDiceRoller.roll("3,10d1", [], [:lowest])
+      60 = ExDiceRoller.roll("5d1,3d1,60d1,10d1", [], [:highest])
     end
 
     test "basic arithmetic with variables" do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -33,6 +33,23 @@ defmodule ExDiceRoller.ParserTest do
       assert {:ok, expected} == Parser.parse(tokens)
     end
 
+    test "separator" do
+      tokens = [
+        {:digit, 1, '2'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '4'},
+        {:",", 1, ','},
+        {:digit, 1, '1'},
+        {:roll, 1, 'd'},
+        {:digit, 1, '6'}
+      ]
+
+      expected =
+        {:sep, {:roll, {:digit, '2'}, {:digit, '4'}}, {:roll, {:digit, '1'}, {:digit, '6'}}}
+
+      assert {:ok, expected} == Parser.parse(tokens)
+    end
+
     test "variable" do
       tokens = [
         {:digit, 1, '1'},

--- a/test/sigil_test.exs
+++ b/test/sigil_test.exs
@@ -26,6 +26,15 @@ defmodule ExDiceRoller.SigilTest do
       assert 9 == ExDiceRoller.execute(fun)
     end
 
+    test "choose highest/lowest" do
+      fun = ~a/5d1,6d1/
+      assert is_function(fun)
+      assert 6 == ExDiceRoller.execute(fun)
+      assert 6 == ~a/5d1,6d1/rh
+      assert 5 == ~a/5d1,6d1/rl
+      assert 5 == ~a/5d1,5d1/r
+    end
+
     test "complex" do
       fun = ~a|1d20+(2d4)d(3d10)/5|
       assert is_function(fun)

--- a/test/tokenizer_test.exs
+++ b/test/tokenizer_test.exs
@@ -66,6 +66,18 @@ defmodule ExDiceRoller.TokenizerTest do
     assert {:ok, expected} == Tokenizer.tokenize("(78*5)")
   end
 
+  test "separator" do
+    expected = [
+      {:digit, 1, '5'},
+      {:",", 1, ','},
+      {:digit, 1, '6'},
+      {:",", 1, ','},
+      {:digit, 1, '7'}
+    ]
+
+    assert {:ok, expected} == Tokenizer.tokenize("5,6,7")
+  end
+
   test "variables" do
     assert {:ok, [{:var, 1, 'x'}]} = Tokenizer.tokenize("x")
 


### PR DESCRIPTION
* addition of the `,` to dice rolls, allowing for choosing highest/lowest of the values on either side
* addition of `h` and `l` to sigil to allow selection or highest or lowest of calculated values on either side of `,`