### PR TITLE
improve call structure and end-user usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ iex> ExDiceRoller.roll("1d20-(5*6)")
 iex> ExDiceRoller.roll("1d4d6")    
 #=> 10
 
-iex> ExDiceRoller.roll("(1d4+2)d((5*6)d20-5)", []) 
+iex> ExDiceRoller.roll("(1d4+2)d((5*6)d20-5)") 
 #=> 566
 
 # variable usage
@@ -78,17 +78,17 @@ iex> ExDiceRoller.roll("1dx+y", [x: 20, y: 13])
 #=> 16
 
 # save each die roll
-iex> ExDiceRoller.roll("3d8", [], [:keep])
+iex> ExDiceRoller.roll("3d8", opts: [:keep])
 #=> [3, 3, 4]
 
 # save each die roll, adding each die's counterpart to the other
-iex> ExDiceRoller.roll("5d1+5d10", [], [:keep])    
+iex> ExDiceRoller.roll("5d1+5d10", opts: [:keep])    
 #=> [3, 5, 7, 7, 2]
 
-iex> ExDiceRoller.roll("5d1+5d10", [], [:keep, :explode])
+iex> ExDiceRoller.roll("5d1+5d10", opts: [:keep, :explode])
 #=> [7, 3, 2, 4, 10]
 
-iex> ExDiceRoller.roll("1d6", [], [:explode])
+iex> ExDiceRoller.roll("1d6", opts: [:explode])
 #=> 9
 ```
 
@@ -105,7 +105,7 @@ iex> {:ok, roll_fun} = ExDiceRoller.compile("1d6 - (3d10)d5 + (1d50)/5")
 iex> ExDiceRoller.execute(roll_fun)
 #=> -16
 
-iex> roll_fun.([], [])
+iex> roll_fun.([])
 #=> -43
 
 iex> {:ok, roll_fun} = ExDiceRoller.compile("1dx+10")
@@ -117,7 +117,7 @@ iex> ExDiceRoller.execute(roll_fun, [x: 5])
 iex> ExDiceRoller.execute(roll_fun, x: "10d100")
 #=> 523
 
-iex> ExDiceRoller.execute(roll_fun, [x: "10d100"], [:keep])
+iex> ExDiceRoller.execute(roll_fun, [x: "10d100", opts: [:keep]])
 #=> [11, 11, 16, 25, 27, 16, 55, 24, 50, 12]
 ```
 
@@ -165,19 +165,19 @@ iex> ~a/5d1+5d10/k
 iex> ExDiceRoller.start_cache()
 #=> {:ok, ExDiceRoller.Cache}
 
-iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: 5], [:cache])
+iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: 5, cache: true])
 #=> 34
 
 iex> ExDiceRoller.Cache.all()
 #=> [{"xdy-2d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}]
 
-iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: "2d6"], [:cache])
+iex> ExDiceRoller.roll("xdy-2d4", [x: 10, y: "2d6", cache: true])
 #=> 29
 
 iex> ExDiceRoller.Cache.all()
 #=> [{"xdy-2d4", #Function<1.86580672/2 in ExDiceRoller.Compiler.compile/1>}]
 
-iex> ExDiceRoller.roll("1d6+3d4", [], [:cache])
+iex> ExDiceRoller.roll("1d6+3d4", cache: true)
 #=> 10
 
 iex> ExDiceRoller.Cache.all()
@@ -249,10 +249,10 @@ iex(5)> {:ok, parse_tree} = ExDiceRoller.parse(tokens)
 iex(6)> {:ok, roll_fun} = ExDiceRoller.compile(parse_tree)
 {:ok, #Function<12.11371143/0 in ExDiceRoller.Compiler.compile_roll/4>}
 
-iex(7)> roll_fun.([], [])
+iex(7)> roll_fun.([])
 739
 
-iex(8)> roll_fun.([], [])
+iex(8)> roll_fun.([])
 905
 
 iex(9)> ExDiceRoller.Compiler.fun_info(roll_fun)

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ iex> ExDiceRoller.execute(roll_fun, [x: 5])
 iex> ExDiceRoller.execute(roll_fun, x: "10d100")
 #=> 523
 
-iex> ExDiceRoller.execute(roll_fun, [x: "10d100", opts: [:keep]])
+iex> ExDiceRoller.execute(roll_fun, x: "10d100", opts: [:keep])
 #=> [11, 11, 16, 25, 27, 16, 55, 24, 50, 12]
 ```
 
 ## Sigil Usage
 
-ExDiceRoller introduces a new sigil, `~a`, with the same set of options as `ExDiceRoller.roll/3`.
+ExDiceRoller introduces a new sigil, `~a`, with the same set of options as `ExDiceRoller.roll/2`.
 
 ```elixir
 # import the sigil inside any module that will use it
@@ -256,24 +256,29 @@ iex(8)> roll_fun.([])
 905
 
 iex(9)> ExDiceRoller.Compiler.fun_info(roll_fun)
-{#Function<9.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
-:"-compile_roll/4-fun-0-",
-[
-  {#Function<1.16543174/1 in ExDiceRoller.Compiler.compile_add/4>,
-    :"-compile_add/4-fun-1-",
+{#Function<0.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+ :"-compile_roll/2-fun-0-",
+ [
+   {#Function<1.102777967/1 in ExDiceRoller.Compilers.Math.compile_add/2>,
+    :"-compile_add/2-fun-3-",
     [
-      {#Function<12.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
-      :"-compile_roll/4-fun-3-", [1, 4]},
-      2
+      {#Function<3.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+       :"-compile_roll/2-fun-3-", [1, 4]},
+      2.56
     ]},
-  {#Function<14.16543174/1 in ExDiceRoller.Compiler.compile_sub/4>,
-    :"-compile_sub/4-fun-1-",
+   {#Function<21.102777967/1 in ExDiceRoller.Compilers.Math.compile_sub/2>,
+    :"-compile_sub/2-fun-3-",
     [
-      {#Function<12.16543174/1 in ExDiceRoller.Compiler.compile_roll/4>,
-      :"-compile_roll/4-fun-3-", [30, 20]},
+      {#Function<1.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+       :"-compile_roll/2-fun-1-",
+       [
+         {#Function<19.102777967/1 in ExDiceRoller.Compilers.Math.compile_mul/2>,
+          :"-compile_mul/2-fun-7-", [5, 6]},
+         20
+       ]},
       5
     ]}
-]}
+ ]}
 ```
 
 

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -21,16 +21,16 @@ defmodule ExDiceRoller.Cache do
       iex> ExDiceRoller.start_cache()
       iex> ExDiceRoller.Cache.all()
       []
-      iex> ExDiceRoller.roll("2d6+1d5", [], [:cache])
+      iex> ExDiceRoller.roll("2d6+1d5", cache: true)
       9
       iex> [{"2d6+1d5", _}] = ExDiceRoller.Cache.all()
-      iex> ExDiceRoller.roll("2d6+1d5", [], [:cache])
+      iex> ExDiceRoller.roll("2d6+1d5", cache: true)
       11
       iex> [{"2d6+1d5", _}] = ExDiceRoller.Cache.all()
-      iex> ExDiceRoller.roll("1d4+x", [x: 3], [:cache])
+      iex> ExDiceRoller.roll("1d4+x", [x: 3, cache: true])
       7
       iex> [{"1d4+x", _}, {"2d6+1d5", _}] = ExDiceRoller.Cache.all()
-      iex> ExDiceRoller.roll("1d4+x", [x: 3], [:cache])
+      iex> ExDiceRoller.roll("1d4+x", [x: 3, cache: true])
       7
   """
 

--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -36,7 +36,7 @@ defmodule ExDiceRoller.Compiler do
       > fun = ExDiceRoller.Compiler.compile(parsed)
       #Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>
 
-      > fun.([], [])
+      > fun.([])
       4
 
       > ExDiceRoller.Compiler.fun_info(fun)
@@ -72,11 +72,10 @@ defmodule ExDiceRoller.Compiler do
   alias ExDiceRoller.Compilers.{Math, Roll, Separator, Variable}
 
   @type compiled_val :: compiled_fun | calculated_val
-  @type compiled_fun :: (args, opts -> calculated_val)
+  @type compiled_fun :: (args -> calculated_val)
   @type calculated_val :: number | list(number)
   @type fun_info_tuple :: {function, atom, list(any)}
   @type args :: Keyword.t()
-  @type opts :: list(atom | {atom, any})
 
   @doc "Compiles the expression into a `t:compiled_val/0`."
   @callback compile(Parser.expression()) :: compiled_val
@@ -98,7 +97,7 @@ defmodule ExDiceRoller.Compiler do
       iex> {:ok, parsed} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {{:operator, '+'}, {:roll, 1, 2}, {:var, 'x'}}}
       iex> fun = ExDiceRoller.Compiler.compile(parsed)
-      iex> fun.([x: 1], [:explode])
+      iex> fun.([x: 1, opts: [:explode]])
       2
 
   During calculation, float values are left as float for as long as possible.
@@ -112,13 +111,13 @@ defmodule ExDiceRoller.Compiler do
 
     compiled =
       case is_function(compiled) do
-        false -> fn _args, _opts -> compiled end
+        false -> fn _args -> compiled end
         true -> compiled
       end
 
-    fn args, opts ->
+    fn args ->
       args
-      |> compiled.(opts)
+      |> compiled.()
       |> round_val()
     end
   end

--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -34,37 +34,37 @@ defmodule ExDiceRoller.Compiler do
           {:roll, 1, 6}}}
 
       > fun = ExDiceRoller.Compiler.compile(parsed)
-      #Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>
+      #Function<1.51809653/1 in ExDiceRoller.Compiler.compile/1>
 
       > fun.([])
-      4
+      11
 
       > ExDiceRoller.Compiler.fun_info(fun)
-      {#Function<0.47893785/2 in ExDiceRoller.Compiler.compile_add/4>,
-        :"-compile_add/4-fun-0-",
-        [
-          {#Function<13.47893785/2 in ExDiceRoller.Compiler.compile_sub/4>,
-            :"-compile_sub/4-fun-0-",
+      {#Function<0.102777967/1 in ExDiceRoller.Compilers.Math.compile_add/2>,
+      :"-compile_add/2-fun-1-",
+      [
+        {#Function<20.102777967/1 in ExDiceRoller.Compilers.Math.compile_sub/2>,
+          :"-compile_sub/2-fun-1-",
+          [
+            {#Function<3.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+            :"-compile_roll/2-fun-3-", [1, 4]},
+            {#Function<5.102777967/1 in ExDiceRoller.Compilers.Math.compile_div/2>,
+            :"-compile_div/2-fun-3-",
             [
-              {#Function<12.47893785/2 in ExDiceRoller.Compiler.compile_roll/4>,
-              :"-compile_roll/4-fun-3-", [1, 4]},
-              {#Function<4.47893785/2 in ExDiceRoller.Compiler.compile_div/4>,
-              :"-compile_div/4-fun-1-",
-              [
-                {#Function<12.47893785/2 in ExDiceRoller.Compiler.compile_roll/4>,
-                  :"-compile_roll/4-fun-3-", [3, 6]},
-                2
-              ]}
-            ]},
-          {#Function<9.47893785/2 in ExDiceRoller.Compiler.compile_roll/4>,
-            :"-compile_roll/4-fun-0-",
-            [
-              {#Function<12.47893785/2 in ExDiceRoller.Compiler.compile_roll/4>,
-              :"-compile_roll/4-fun-3-", [1, 4]},
-              {#Function<12.47893785/2 in ExDiceRoller.Compiler.compile_roll/4>,
-              :"-compile_roll/4-fun-3-", [1, 6]}
+              {#Function<3.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+                :"-compile_roll/2-fun-3-", [3, 6]},
+              2
             ]}
-        ]}
+          ]},
+        {#Function<0.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+          :"-compile_roll/2-fun-0-",
+          [
+            {#Function<3.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+            :"-compile_roll/2-fun-3-", [1, 4]},
+            {#Function<3.31405244/1 in ExDiceRoller.Compilers.Roll.compile_roll/2>,
+            :"-compile_roll/2-fun-3-", [1, 6]}
+          ]}
+      ]}
 
   """
 

--- a/lib/compilers/math.ex
+++ b/lib/compilers/math.ex
@@ -7,9 +7,9 @@ defmodule ExDiceRoller.Compilers.Math do
       iex> {:ok, parse_tree} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {{:operator, '+'}, 1, {:var, 'x'}}}
       iex> fun = ExDiceRoller.Compilers.Math.compile(parse_tree)
-      iex> fun.([x: 2], [])
+      iex> fun.([x: 2])
       3
-      iex> fun.([x: 2.4], [])
+      iex> fun.([x: 2.4])
       3.4
 
   ExDiceRoller uses [infix notation](https://en.wikipedia.org/wiki/Infix_notation)
@@ -75,25 +75,25 @@ defmodule ExDiceRoller.Compilers.Math do
             Compiler.compiled_val()
 
     defp unquote(:"compile_#{name}")(l, r) when is_function(l) and is_function(r) do
-      fn args, opts ->
-        ListComprehension.apply(l.(args, opts), r.(args, opts), unquote(fun), @err_name, &op/3)
+      fn args ->
+        ListComprehension.apply(l.(args), r.(args), unquote(fun), @err_name, &op/3)
       end
     end
 
     defp unquote(:"compile_#{name}")(l, r) when is_function(l) do
-      fn args, opts ->
-        ListComprehension.apply(l.(args, opts), r, unquote(fun), @err_name, &op/3)
+      fn args ->
+        ListComprehension.apply(l.(args), r, unquote(fun), @err_name, &op/3)
       end
     end
 
     defp unquote(:"compile_#{name}")(l, r) when is_function(r) do
-      fn args, opts ->
-        ListComprehension.apply(l, r.(args, opts), unquote(fun), @err_name, &op/3)
+      fn args ->
+        ListComprehension.apply(l, r.(args), unquote(fun), @err_name, &op/3)
       end
     end
 
     defp unquote(:"compile_#{name}")(l, r) do
-      fn _, _ ->
+      fn _ ->
         ListComprehension.apply(l, r, unquote(fun), @err_name, &op/3)
       end
     end

--- a/lib/compilers/roll.ex
+++ b/lib/compilers/roll.ex
@@ -29,7 +29,7 @@ defmodule ExDiceRoller.Compilers.Roll do
   5. the sum total result of all rolls is recorded and used
 
   You can utilize this mechanic by specifying the `:explode` option for
-  ExDiceRoller.roll/3 calls, or specifying the `e` flag when using the `~a`
+  ExDiceRoller.roll/2 calls, or specifying the `e` flag when using the `~a`
   sigil. This option can be used with any ExDiceRoller roll option.
 
   It should also be noted that the exploding dice mechanic is not applied to a

--- a/lib/compilers/roll.ex
+++ b/lib/compilers/roll.ex
@@ -9,9 +9,9 @@ defmodule ExDiceRoller.Compilers.Roll do
       iex> {:ok, parse_tree} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {:roll, 1, 6}}
       iex> fun = ExDiceRoller.Compilers.Roll.compile(parse_tree)
-      iex> fun.([], [])
+      iex> fun.([])
       3
-      iex> fun.([], [])
+      iex> fun.([])
       2
 
   ## Options
@@ -44,11 +44,11 @@ defmodule ExDiceRoller.Compilers.Roll do
       iex> {:ok, parse_tree} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {:roll, 1, 6}}
       iex> fun = ExDiceRoller.Compilers.Roll.compile(parse_tree)
-      iex> fun.([], [:explode])
+      iex> fun.(opts: [:explode])
       3
-      iex> fun.([], [:explode])
+      iex> fun.(opts: [:explode])
       2
-      iex> fun.([], [:explode])
+      iex> fun.(opts: [:explode])
       10
 
       iex> import ExDiceRoller.Sigil
@@ -73,7 +73,7 @@ defmodule ExDiceRoller.Compilers.Roll do
       iex> {:ok, parse_tree} = ExDiceRoller.Parser.parse(tokens)
       {:ok, {:roll, 5, 6}}
       iex> fun = ExDiceRoller.Compilers.Roll.compile(parse_tree)
-      iex> fun.([], [:keep])
+      iex> fun.(opts: [:keep])
       [3, 2, 6, 4, 5]
 
 
@@ -93,19 +93,19 @@ defmodule ExDiceRoller.Compilers.Roll do
   @spec compile_roll(Compiler.compiled_val(), Compiler.compiled_val()) :: Compiler.compiled_fun()
 
   defp compile_roll(num, sides) when is_function(num) and is_function(sides) do
-    fn args, opts -> roll_prep(num.(args, opts), sides.(args, opts), opts) end
+    fn args -> roll_prep(num.(args), sides.(args), args) end
   end
 
   defp compile_roll(num, sides) when is_function(num),
-    do: fn args, opts -> roll_prep(num.(args, opts), sides, opts) end
+    do: fn args -> roll_prep(num.(args), sides, args) end
 
   defp compile_roll(num, sides) when is_function(sides),
-    do: fn args, opts -> roll_prep(num, sides.(args, opts), opts) end
+    do: fn args -> roll_prep(num, sides.(args), args) end
 
   defp compile_roll(num, sides),
-    do: fn _args, opts -> roll_prep(num, sides, opts) end
+    do: fn args -> roll_prep(num, sides, args) end
 
-  @spec roll_prep(number, number, list(atom | tuple)) :: integer
+  @spec roll_prep(Compiler.calculated_val, Compiler.calculated_val, list(atom | tuple)) :: integer
 
   defp roll_prep(0, _, _), do: 0
   defp roll_prep(_, 0, _), do: 0
@@ -114,13 +114,13 @@ defmodule ExDiceRoller.Compilers.Roll do
     raise(ArgumentError, "neither number of dice nor number of sides can be less than 0")
   end
 
-  defp roll_prep(num, sides, opts) do
+  defp roll_prep(num, sides, args) do
     num = Compiler.round_val(num)
     sides = Compiler.round_val(sides)
-    explode? = :explode in opts
+    explode? = :explode in Keyword.get(args, :opts, [])
 
     fun =
-      case :keep in opts do
+      case :keep in Keyword.get(args, :opts, []) do
         true -> keep_roll()
         false -> normal_roll()
       end

--- a/lib/compilers/separator.ex
+++ b/lib/compilers/separator.ex
@@ -60,7 +60,7 @@ defmodule ExDiceRoller.Compilers.Separator do
       iex> ExDiceRoller.roll("3, 5d6", opts: [:keep])
       [3, 4, 4, 6, 3]
 
-      iex> ExDiceRoller.roll("4, xd5", [x: ["1d4", 2.5], opts: [:keep]])
+      iex> ExDiceRoller.roll("4, xd5", x: ["1d4", 2.5], opts: [:keep])
       [5, 4, 4, 4]
 
       iex> ExDiceRoller.roll("2d4, 1d8", opts: [:keep])

--- a/lib/compilers/separator.ex
+++ b/lib/compilers/separator.ex
@@ -10,17 +10,17 @@ defmodule ExDiceRoller.Compilers.Separator do
 
   Examples:
 
-      iex> ExDiceRoller.roll("1,2", [], [])
+      iex> ExDiceRoller.roll("1,2")
       2
-      iex> ExDiceRoller.roll("1,1", [], [])
+      iex> ExDiceRoller.roll("1,1")
       1
-      iex> ExDiceRoller.roll("1,2", [], [:highest])
+      iex> ExDiceRoller.roll("1,2", opts: [:highest])
       2
-      iex> ExDiceRoller.roll("1,2", [], [:lowest])
+      iex> ExDiceRoller.roll("1,2", opts: [:lowest])
       1
-      iex> ExDiceRoller.roll("1d6+2,10d8+3", [], [:highest])
+      iex> ExDiceRoller.roll("1d6+2,10d8+3", opts: [:highest])
       49
-      iex> ExDiceRoller.roll("1d6+8,10d8+5", [], [:lowest])
+      iex> ExDiceRoller.roll("1d6+8,10d8+5", opts: [:lowest])
       14
 
 
@@ -29,9 +29,9 @@ defmodule ExDiceRoller.Compilers.Separator do
 
   Examples:
 
-      iex> ExDiceRoller.roll("(5d1,2d1)+5", [], [:highest])
+      iex> ExDiceRoller.roll("(5d1,2d1)+5", opts: [:highest])
       10
-      iex> ExDiceRoller.roll("(5d1,2d1)+5", [], [:lowest])
+      iex> ExDiceRoller.roll("(5d1,2d1)+5", opts: [:lowest])
       7
 
   ## Separator Use And Keeping Dice
@@ -45,25 +45,25 @@ defmodule ExDiceRoller.Compilers.Separator do
   values from both lists by index location.
 
 
-      iex> ExDiceRoller.roll("5d6,5d100", [], [:keep, :lowest])
+      iex> ExDiceRoller.roll("5d6,5d100", opts: [:keep, :lowest])
       [2, 2, 6, 4, 5]
-      iex> ExDiceRoller.roll("5d6,5d100", [], [:keep, :highest])
+      iex> ExDiceRoller.roll("5d6,5d100", opts: [:keep, :highest])
       [47, 6, 49, 91, 54]
 
-      iex> ExDiceRoller.roll("(5d2,5d6)+5", [], [:highest, :keep])
+      iex> ExDiceRoller.roll("(5d2,5d6)+5", opts: [:highest, :keep])
       [7, 9, 9, 11, 6]
-      iex> ExDiceRoller.roll("(5d1,5d100)+5", [], [:lowest, :keep])
+      iex> ExDiceRoller.roll("(5d1,5d100)+5", opts: [:lowest, :keep])
       [6, 6, 6, 6, 6]
 
-      iex> ExDiceRoller.roll("5d6, 3", [], [:keep])
+      iex> ExDiceRoller.roll("5d6, 3", opts: [:keep])
       [3, 3, 6, 4, 5]
-      iex> ExDiceRoller.roll("3, 5d6", [], [:keep])
+      iex> ExDiceRoller.roll("3, 5d6", opts: [:keep])
       [3, 4, 4, 6, 3]
 
-      iex> ExDiceRoller.roll("4, xd5", [x: ["1d4", 2.5]], [:keep])
+      iex> ExDiceRoller.roll("4, xd5", [x: ["1d4", 2.5], opts: [:keep]])
       [5, 4, 4, 4]
 
-      iex> ExDiceRoller.roll("2d4, 1d8", [], [:keep])
+      iex> ExDiceRoller.roll("2d4, 1d8", opts: [:keep])
       ** (ArgumentError) cannot use separator on lists of differing lengths
   """
 
@@ -77,21 +77,23 @@ defmodule ExDiceRoller.Compilers.Separator do
 
   @spec compile_sep(Compiler.compiled_val(), Compiler.compiled_val()) :: Compiler.compiled_fun()
   defp compile_sep(l, r) when is_function(l) and is_function(r),
-    do: fn args, opts -> high_low(l.(args, opts), r.(args, opts), opts) end
+    do: fn args -> high_low(l.(args), r.(args), args) end
 
   defp compile_sep(l, r) when is_function(l),
-    do: fn args, opts -> high_low(l.(args, opts), r, opts) end
+    do: fn args -> high_low(l.(args), r, args) end
 
   defp compile_sep(l, r) when is_function(r),
-    do: fn args, opts -> high_low(l, r.(args, opts), opts) end
+    do: fn args -> high_low(l, r.(args), args) end
 
-  defp compile_sep(l, r), do: fn _args, opts -> high_low(l, r, opts) end
+  defp compile_sep(l, r), do: fn args -> high_low(l, r, args) end
 
-  @spec high_low(Compiler.calculated_val(), Compiler.calculated_val(), Compiler.opts()) ::
+  @spec high_low(Compiler.calculated_val(), Compiler.calculated_val(), Compiler.args()) ::
           Compiler.calculated_val()
   defp high_low(l, l, _), do: l
 
-  defp high_low(l, r, opts) when is_list(opts) do
+  defp high_low(l, r, args) when is_list(args) do
+    opts = Keyword.get(args, :opts, [])
+
     case Enum.find(opts, &(&1 in [:highest, :lowest])) do
       :highest -> ListComprehension.apply(l, r, :highest, "separator", &do_high_low/3)
       :lowest -> ListComprehension.apply(l, r, :lowest, "separator", &do_high_low/3)

--- a/lib/compilers/variable.ex
+++ b/lib/compilers/variable.ex
@@ -28,11 +28,11 @@ defmodule ExDiceRoller.Compilers.Variable do
       82
       iex> ExDiceRoller.roll("xdy+z", [x: 5, y: 10, z: ~a/15d100/])
       739
-      iex> ExDiceRoller.roll("xdy+z", [x: [1, 2, 3], y: 1, z: 5], [:keep])
+      iex> ExDiceRoller.roll("xdy+z", [x: [1, 2, 3], y: 1, z: 5, opts: [:keep]])
       [6, 6, 6, 6, 6, 6]
-      iex> ExDiceRoller.roll("xdy+z", [x: 1, y: [1, 10, 100], z: -6], [:keep])
+      iex> ExDiceRoller.roll("xdy+z", [x: 1, y: [1, 10, 100], z: -6, opts: [:keep]])
       [-5, 0, 68]
-      iex> ExDiceRoller.roll("xdy+z", [x: [~a/1d2/, "1d4+1"], y: ["3,4d20/2", ~a/1d6/], z: 2], [:keep])
+      iex> ExDiceRoller.roll("xdy+z", [x: [~a/1d2/, "1d4+1"], y: ["3,4d20/2", ~a/1d6/], z: 2, opts: [:keep]])
       [3, 4, 5, 5, 3, 7, 4, 5, 4, 3, 5, 4, 3, 4, 7, 3, 5, 4, 4, 5]
 
       iex> ExDiceRoller.roll("1+x")
@@ -46,32 +46,32 @@ defmodule ExDiceRoller.Compilers.Variable do
   def compile({:var, _} = var), do: compile_var(var)
 
   @spec compile_var({:var, charlist}) :: Compiler.compiled_fun()
-  defp compile_var({:var, var}), do: fn args, opts -> var_final(var, args, opts) end
+  defp compile_var({:var, var}), do: fn args -> var_final(var, args) end
 
-  @spec var_final(charlist, Compiler.args(), Compiler.opts()) :: number
-  defp var_final(var, args, opts) do
+  @spec var_final(charlist, Keyword.t()) :: number
+  defp var_final(var, args) do
     key = var |> to_string() |> String.to_atom()
 
     args
     |> Keyword.get(key)
-    |> var_final_arg(var, opts)
+    |> var_final_arg(var, args)
   end
 
-  @spec var_final_arg(any, charlist, Compiler.opts()) :: number
+  @spec var_final_arg(any, charlist, Keyword.t()) :: number
   defp var_final_arg(nil, var, _),
     do: raise(ArgumentError, "no variable #{inspect(var)} was found in the arguments")
 
   defp var_final_arg(val, _, _) when is_number(val), do: val
-  defp var_final_arg(val, _, opts) when is_function(val), do: val.([], opts)
+  defp var_final_arg(val, _, args) when is_function(val), do: val.(args)
 
-  defp var_final_arg(val, var, opts) when is_bitstring(val) do
+  defp var_final_arg(val, var, args) when is_bitstring(val) do
     {:ok, tokens} = Tokenizer.tokenize(val)
     {:ok, parsed} = Parser.parse(tokens)
     compiled_arg = Compiler.delegate(parsed)
-    var_final_arg(compiled_arg, var, opts)
+    var_final_arg(compiled_arg, var, args)
   end
 
-  defp var_final_arg(val, var, opts) when is_list(val) do
-    Enum.map(val, &var_final_arg(&1, var, opts))
+  defp var_final_arg(val, var, args) when is_list(val) do
+    Enum.map(val, &var_final_arg(&1, var, args))
   end
 end

--- a/lib/compilers/variable.ex
+++ b/lib/compilers/variable.ex
@@ -24,15 +24,15 @@ defmodule ExDiceRoller.Compilers.Variable do
       ExDiceRoller.Sigil
       iex> ExDiceRoller.roll(~a/1+x/, [x: 5])
       6
-      iex> ExDiceRoller.roll("xdy+z", [x: 5, y: 10, z: 50])
+      iex> ExDiceRoller.roll("xdy+z", x: 5, y: 10, z: 50)
       82
       iex> ExDiceRoller.roll("xdy+z", [x: 5, y: 10, z: ~a/15d100/])
       739
-      iex> ExDiceRoller.roll("xdy+z", [x: [1, 2, 3], y: 1, z: 5, opts: [:keep]])
+      iex> ExDiceRoller.roll("xdy+z", x: [1, 2, 3], y: 1, z: 5, opts: [:keep])
       [6, 6, 6, 6, 6, 6]
       iex> ExDiceRoller.roll("xdy+z", [x: 1, y: [1, 10, 100], z: -6, opts: [:keep]])
       [-5, 0, 68]
-      iex> ExDiceRoller.roll("xdy+z", [x: [~a/1d2/, "1d4+1"], y: ["3,4d20/2", ~a/1d6/], z: 2, opts: [:keep]])
+      iex> ExDiceRoller.roll("xdy+z", x: [~a/1d2/, "1d4+1"], y: ["3,4d20/2", ~a/1d6/], z: 2, opts: [:keep])
       [3, 4, 5, 5, 3, 7, 4, 5, 4, 3, 5, 4, 3, 4, 7, 3, 5, 4, 4, 5]
 
       iex> ExDiceRoller.roll("1+x")

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -2,7 +2,7 @@ defmodule ExDiceRoller do
   @moduledoc """
   Converts strings into dice rolls and returns expected results. Ignores any
   spaces, including tabs and newlines, in the provided string. A roll can be
-  invoked via `ExDiceRoller.roll/3`.
+  invoked via `ExDiceRoller.roll/2`.
 
       iex> ExDiceRoller.roll("2d6+3")
       8
@@ -257,7 +257,7 @@ defmodule ExDiceRoller do
 
       iex> ExDiceRoller.roll("1+x", [x: 1])
       2
-      iex> ExDiceRoller.roll("1+x", [x: 1.4])
+      iex> ExDiceRoller.roll("1+x", x: 1.4)
       2
       iex> ExDiceRoller.roll("1+x", [x: 1.5])
       3
@@ -274,7 +274,7 @@ defmodule ExDiceRoller do
       iex> ExDiceRoller.start_cache(ExDiceRoller.Cache)
       iex> ExDiceRoller.roll("(1d6)d4-3+y", [y: 3, cache: true])
       10
-      iex> ExDiceRoller.roll("1d2+y", [y: 1, opts: [:cache, :explode]])
+      iex> ExDiceRoller.roll("1d2+y", y: 1, opts: [:cache, :explode])
       2
       iex> ExDiceRoller.roll("1d2+y", [y: 2, opts: [:cache, :explode]])
       11

--- a/lib/list_comprehension.ex
+++ b/lib/list_comprehension.ex
@@ -18,27 +18,27 @@ defmodule ExDiceRoller.ListComprehension do
   Example of one side of an expression being a kept list and the other a value:
 
       iex> {:ok, fun} = ExDiceRoller.compile("5d6+11")
-      iex> fun.([], [:keep])
+      iex> fun.(opts: [:keep])
       [14, 13, 17, 15, 16]
 
   Example of both sides being lists:
 
       iex> {:ok, fun} = ExDiceRoller.compile("5d6+(5d10+20)")
-      iex> fun.([], [:keep])
+      iex> fun.(opts: [:keep])
       [25, 32, 34, 30, 26]
 
   Example with lists of differing lengths:
 
-      iex> ExDiceRoller.roll("5d6+6d6", [], [:keep])
+      iex> ExDiceRoller.roll("5d6+6d6", opts: [:keep])
       ** (ArgumentError) cannot use math operators on lists of differing lengths
 
   Example of dice rolls of dice rolls:
 
-      iex> ExDiceRoller.roll("1d1d4", [], [:keep])
+      iex> ExDiceRoller.roll("1d1d4", opts: [:keep])
       [1]
-      iex> ExDiceRoller.roll("2d1d4", [], [:keep])
+      iex> ExDiceRoller.roll("2d1d4", opts: [:keep])
       [4, 2]
-      iex> ExDiceRoller.roll("2d6d4", [], [:keep])
+      iex> ExDiceRoller.roll("2d6d4", opts: [:keep])
       [2, 4, 4, 2, 3, 2, 4, 4, 4]
   """
 
@@ -47,7 +47,6 @@ defmodule ExDiceRoller.ListComprehension do
   @type left :: Compiler.compiled_val() | list(Compiler.compiled_val())
   @type right :: Compiler.compiled_val() | list(Compiler.compiled_val())
   @type return_val :: Compiler.compiled_val() | list(Compiler.compiled_val())
-  @type opts :: any | list(any)
 
   @doc """
   Applies the given function and options to both the left and right sides of
@@ -55,23 +54,23 @@ defmodule ExDiceRoller.ListComprehension do
   against each element of the list. Any resulting lists or nested lists, will
   be flattened to a single list.
   """
-  @spec flattened_apply(left, right, opts, function) :: return_val
+  @spec flattened_apply(left, right, any, function) :: return_val
 
-  def flattened_apply(l, r, opts, fun) when is_list(l) do
+  def flattened_apply(l, r, args, fun) when is_list(l) do
     l
     |> List.flatten()
-    |> Enum.map(&flattened_apply(&1, r, opts, fun))
+    |> Enum.map(&flattened_apply(&1, r, args, fun))
     |> List.flatten()
   end
 
-  def flattened_apply(l, r, opts, fun) when is_list(r) do
+  def flattened_apply(l, r, args, fun) when is_list(r) do
     r
     |> List.flatten()
-    |> Enum.map(&flattened_apply(l, &1, opts, fun))
+    |> Enum.map(&flattened_apply(l, &1, args, fun))
     |> List.flatten()
   end
 
-  def flattened_apply(l, r, opts, fun), do: fun.(l, r, opts)
+  def flattened_apply(l, r, args, fun), do: fun.(l, r, args)
 
   @doc """
   Applies the given function and options to both the left and right sides of
@@ -81,23 +80,23 @@ defmodule ExDiceRoller.ListComprehension do
   they are not the same size, an error is raised. Otherwise, the values of
   each list are applied to their counterpart in the other list.
   """
-  @spec apply(left, right, opts, String.t(), function) :: return_val
+  @spec apply(left, right, any, String.t(), function) :: return_val
 
   def apply(l, r, _, err_name, _) when is_list(l) and is_list(r) and length(l) != length(r) do
     raise ArgumentError, "cannot use #{err_name} on lists of differing lengths"
   end
 
-  def apply(l, r, opts, _, fun) when is_list(l) and is_list(r) do
-    Enum.map(0..(length(l) - 1), &fun.(Enum.at(l, &1), Enum.at(r, &1), opts))
+  def apply(l, r, args, _, fun) when is_list(l) and is_list(r) do
+    Enum.map(0..(length(l) - 1), &fun.(Enum.at(l, &1), Enum.at(r, &1), args))
   end
 
-  def apply(l, r, opts, err_name, fun) when is_list(l) do
-    Enum.map(l, &apply(&1, r, opts, err_name, fun))
+  def apply(l, r, args, err_name, fun) when is_list(l) do
+    Enum.map(l, &apply(&1, r, args, err_name, fun))
   end
 
-  def apply(l, r, opts, err_name, fun) when is_list(r) do
-    Enum.map(r, &apply(l, &1, opts, err_name, fun))
+  def apply(l, r, args, err_name, fun) when is_list(r) do
+    Enum.map(r, &apply(l, &1, args, err_name, fun))
   end
 
-  def apply(l, r, opts, _, fun), do: fun.(l, r, opts)
+  def apply(l, r, args, _, fun), do: fun.(l, r, args)
 end

--- a/lib/sigil.ex
+++ b/lib/sigil.ex
@@ -23,14 +23,14 @@ defmodule ExDiceRoller.Sigil do
       iex> import ExDiceRoller.Sigil
       ExDiceRoller.Sigil
       iex> fun = ~a/1+1/
-      iex> fun.([], [])
+      iex> fun.([])
       2
 
       iex> import ExDiceRoller.Sigil
       iex> fun = ~a/1d4/
-      iex> fun.([], [])
+      iex> fun.([])
       1
-      iex> fun.([], [])
+      iex> fun.([])
       4
 
       iex> import ExDiceRoller.Sigil
@@ -54,7 +54,7 @@ defmodule ExDiceRoller.Sigil do
           fun
 
         true ->
-          fun.([], translated_opts -- [:execute])
+          fun.(opts: translated_opts -- [:execute])
       end
     else
       {:error, reason} -> {:error, {:invalid_option, reason}}

--- a/test/ex_dice_roller_test.exs
+++ b/test/ex_dice_roller_test.exs
@@ -22,7 +22,7 @@ defmodule ExDiceRollerTest do
       2 = ExDiceRoller.roll("1,2")
       3 = ExDiceRoller.roll("3,3")
       83 = ExDiceRoller.roll("11,5,83,42,36")
-      1 = ExDiceRoller.roll("2,1", [], [:lowest])
+      1 = ExDiceRoller.roll("2,1", opts: [:lowest])
       2 = ExDiceRoller.roll("5%3")
       8 = ExDiceRoller.roll("2^3")
     end
@@ -77,8 +77,8 @@ defmodule ExDiceRollerTest do
       6 = ExDiceRoller.roll("1d4 * 2")
       1 = ExDiceRoller.roll("1d4 / 3")
       4 = ExDiceRoller.roll("4d1, 3.1459")
-      3 = ExDiceRoller.roll("3,10d1", [], [:lowest])
-      60 = ExDiceRoller.roll("5d1,3d1,60d1,10d1", [], [:highest])
+      3 = ExDiceRoller.roll("3,10d1", opts: [:lowest])
+      60 = ExDiceRoller.roll("5d1,3d1,60d1,10d1", opts: [:highest])
     end
 
     test "basic arithmetic with variables" do
@@ -92,24 +92,24 @@ defmodule ExDiceRollerTest do
     end
 
     test "list comprehensions" do
-      [3, 12] = ExDiceRoller.roll("2d4 + 2d8", [], [:keep])
-      [1] = ExDiceRoller.roll("1d4 - 2", [], [:keep])
-      [12, 8] = ExDiceRoller.roll("2 * 2d8", [], [:keep])
-      [4, 6] = ExDiceRoller.roll("2d6,2d8", [], [:keep])
-      [6, 3] = ExDiceRoller.roll("2d6, 3", [], [:keep])
-      [6, 3, 3] = ExDiceRoller.roll("3, 3d6", [], [:keep])
+      [3, 12] = ExDiceRoller.roll("2d4 + 2d8", opts: [:keep])
+      [1] = ExDiceRoller.roll("1d4 - 2", opts: [:keep])
+      [12, 8] = ExDiceRoller.roll("2 * 2d8", opts: [:keep])
+      [4, 6] = ExDiceRoller.roll("2d6,2d8", opts: [:keep])
+      [6, 3] = ExDiceRoller.roll("2d6, 3", opts: [:keep])
+      [6, 3, 3] = ExDiceRoller.roll("3, 3d6", opts: [:keep])
     end
 
     test "errors using separator with lists" do
-      assert_raise ArgumentError, fn -> ExDiceRoller.roll("2d4, 1d8", [], [:keep]) end
+      assert_raise ArgumentError, fn -> ExDiceRoller.roll("2d4, 1d8", opts: [:keep]) end
     end
 
     test "errors with lists" do
-      assert_raise ArgumentError, fn -> ExDiceRoller.roll("2d4 + 1d8", [], [:keep]) end
+      assert_raise ArgumentError, fn -> ExDiceRoller.roll("2d4 + 1d8", opts: [:keep]) end
     end
 
     test "keep roll values" do
-      values = ExDiceRoller.roll("3d6", [], [:keep])
+      values = ExDiceRoller.roll("3d6", opts: [:keep])
       require Logger
       assert length(values) == 3
     end
@@ -131,11 +131,11 @@ defmodule ExDiceRollerTest do
 
     test "exploding dice" do
       {:ok, fun} = ExDiceRoller.compile("1d2")
-      assert 1 == ExDiceRoller.execute(fun, [], [:explode])
-      assert 7 == ExDiceRoller.execute(fun, [], [:explode])
-      assert 9 == ExDiceRoller.execute(fun, [], [:explode])
-      assert 9 == ExDiceRoller.execute(fun, [], [:explode])
-      assert 1 == ExDiceRoller.execute(fun, [], [:explode])
+      assert 1 == ExDiceRoller.execute(fun, opts: [:explode])
+      assert 7 == ExDiceRoller.execute(fun, opts: [:explode])
+      assert 9 == ExDiceRoller.execute(fun, opts: [:explode])
+      assert 9 == ExDiceRoller.execute(fun, opts: [:explode])
+      assert 1 == ExDiceRoller.execute(fun, opts: [:explode])
     end
 
     test "that error on a negative number of dice" do
@@ -173,7 +173,7 @@ defmodule ExDiceRollerTest do
 
       assert [] == Cache.all()
 
-      assert 9 == ExDiceRoller.roll(roll, [], [:cache])
+      assert 9 == ExDiceRoller.roll(roll, cache: true)
       assert length(Cache.all()) == 1
     end
 
@@ -183,7 +183,7 @@ defmodule ExDiceRollerTest do
 
       assert [] == Cache.all()
 
-      assert 6 == ExDiceRoller.roll(roll, [x: 7, y: 4], [:cache])
+      assert 6 == ExDiceRoller.roll(roll, x: 7, y: 4, cache: true)
       assert length(Cache.all()) == 1
     end
   end

--- a/test/support/randomized_rolls.ex
+++ b/test/support/randomized_rolls.ex
@@ -52,7 +52,7 @@ defmodule ExDiceRoller.RandomizedRolls do
       |> generate_var_values(max_depth - 1)
 
     try do
-      ExDiceRoller.roll(expr, var_values, build_options())
+      ExDiceRoller.roll(expr, var_values ++ build_options())
       acc
     rescue
       err -> handle_error(err, acceptable_errors, var_values, expr, acc)


### PR DESCRIPTION
Combined variables and arguments into a single keyword list argument. Any calls of the format `f.(arg_list, option_list)` are now `f.(arg_list)`.

Effects:
- `ExDiceRoller.roll/3` is now `ExDiceRoller.roll/2`
- options are now passed via `opts: [:keep, :explode, ...]`
- compiled functions have transitioned from `f/2` to `f/1`
- cache is no longer an option, but is instead it's own argument, see `ExDiceRoller.Cache` for more information and usage examples