### PR TITLE
addition of filters for final value

### DIFF
--- a/lib/compilers/roll.ex
+++ b/lib/compilers/roll.ex
@@ -105,7 +105,8 @@ defmodule ExDiceRoller.Compilers.Roll do
   defp compile_roll(num, sides),
     do: fn args -> roll_prep(num, sides, args) end
 
-  @spec roll_prep(Compiler.calculated_val, Compiler.calculated_val, list(atom | tuple)) :: integer
+  @spec roll_prep(Compiler.calculated_val(), Compiler.calculated_val(), list(atom | tuple)) ::
+          integer
 
   defp roll_prep(0, _, _), do: 0
   defp roll_prep(_, 0, _), do: 0

--- a/test/compiler_test.exs
+++ b/test/compiler_test.exs
@@ -48,5 +48,13 @@ defmodule ExDiceRoller.CompilerTest do
                  ]}
               ]} = result
     end
+
+    test "filters" do
+      assert [4] == ExDiceRoller.roll("6d6", =: 4, opts: :keep)
+      assert [4, 4, 2] == ExDiceRoller.roll("3d8", <: 5, opts: :keep)
+      assert [6, 8, 8] == ExDiceRoller.roll("5d8", >: 4, opts: :keep)
+      assert [7, 5] == ExDiceRoller.roll("5d8", >=: 4, opts: :keep)
+      assert [4, 4, 1] == ExDiceRoller.roll("5d8", <=: 4, opts: :keep)
+    end
   end
 end

--- a/test/randomized_rolls_test.exs
+++ b/test/randomized_rolls_test.exs
@@ -1,7 +1,7 @@
 defmodule ExDiceRoller.RandomizedRollsTest do
   @moduledoc false
 
-  use ExDiceRoller.Case
+  use ExUnit.Case
   require Logger
   alias ExDiceRoller.RandomizedRolls
 
@@ -34,8 +34,8 @@ defmodule ExDiceRoller.RandomizedRollsTest do
     RandomizedRolls.handle_error(
       %ArithmeticError{message: "bad argument in arithmetic expression"},
       [],
-      [],
       "1/0",
+      [],
       []
     )
   end
@@ -46,8 +46,8 @@ defmodule ExDiceRoller.RandomizedRollsTest do
     RandomizedRolls.handle_error(
       %ArgumentError{message: "unexpected error"},
       acceptable_errors,
-      [],
       "1/0",
+      [],
       []
     )
   end


### PR DESCRIPTION
* adds roll arguments that filter final results using standard comparators, such as `[<=: 4]`, `[>: 3]`, and more