### PR TITLE
added helper Args module for working with dice roll args

### DIFF
--- a/lib/args.ex
+++ b/lib/args.ex
@@ -1,0 +1,60 @@
+defmodule ExDiceRoller.Args do
+  @moduledoc "Manages arguments used in ExDiceRoller rolls."
+
+  alias ExDiceRoller.Filters
+
+  @spec use_cache?(Keyword.t()) :: boolean
+  def use_cache?(args) do
+    case Keyword.get(args, :cache, false) do
+      true -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  Retrieves the filters from arguments and a new arguments set with the filters
+  removed.
+  """
+  @spec get_filters(Keyword.t()) :: {list(any), Keyword.t()}
+  def get_filters(args) do
+    Filters.get_filters(args)
+  end
+
+  @doc "Reviews, adds, and cleans the arguments for use throughout ExDiceRoller."
+  @spec sanitize(Keyword.t()) :: Keyword.t()
+  def sanitize([]), do: []
+
+  def sanitize(args) when is_list(args) do
+    case args[:opts] do
+      nil -> Keyword.put(args, :opts, [])
+      val when is_list(val) -> args
+      val -> Keyword.put(args, :opts, [val])
+    end
+  end
+
+  @spec get_options(Keyword.t()) :: list(atom)
+  def get_options(args) do
+    Keyword.get(args, :opts, [])
+  end
+
+  @spec has_option?(Keyword.t(), atom) :: boolean
+  def has_option?(args, key) do
+    key in get_options(args)
+  end
+
+  @doc """
+  Looks for and returns either the first option found from the provided list of
+  atoms, or nil.
+  """
+  @spec find_first(Keyword.t(), list(atom)) :: atom | nil
+  def find_first(args, keys) when is_list(keys) do
+    args
+    |> get_options()
+    |> Enum.find(&(&1 in keys))
+  end
+
+  @spec get_var(Keyword.t(), atom) :: any
+  def get_var(args, var_name) do
+    Keyword.get(args, var_name)
+  end
+end

--- a/lib/compilers/roll.ex
+++ b/lib/compilers/roll.ex
@@ -83,7 +83,7 @@ defmodule ExDiceRoller.Compilers.Roll do
   """
 
   @behaviour ExDiceRoller.Compiler
-  alias ExDiceRoller.{Compiler, ListComprehension}
+  alias ExDiceRoller.{Args, Compiler, ListComprehension}
 
   @impl true
   def compile({:roll, left_expr, right_expr}) do
@@ -118,14 +118,14 @@ defmodule ExDiceRoller.Compilers.Roll do
   defp roll_prep(num, sides, args) do
     num = Compiler.round_val(num)
     sides = Compiler.round_val(sides)
-    explode? = :explode in Keyword.get(args, :opts, [])
 
     fun =
-      case :keep in Keyword.get(args, :opts, []) do
+      case Args.has_option?(args, :keep) do
         true -> keep_roll()
         false -> normal_roll()
       end
 
+    explode? = Args.has_option?(args, :explode)
     ListComprehension.flattened_apply(num, sides, explode?, fun)
   end
 

--- a/lib/compilers/separator.ex
+++ b/lib/compilers/separator.ex
@@ -68,7 +68,7 @@ defmodule ExDiceRoller.Compilers.Separator do
   """
 
   @behaviour ExDiceRoller.Compiler
-  alias ExDiceRoller.{Compiler, ListComprehension}
+  alias ExDiceRoller.{Args, Compiler, ListComprehension}
 
   @impl true
   def compile({:sep, left_expr, right_expr}) do
@@ -92,9 +92,7 @@ defmodule ExDiceRoller.Compilers.Separator do
   defp high_low(l, l, _), do: l
 
   defp high_low(l, r, args) when is_list(args) do
-    opts = Keyword.get(args, :opts, [])
-
-    case Enum.find(opts, &(&1 in [:highest, :lowest])) do
+    case Args.find_first(args, [:highest, :lowest]) do
       :highest -> ListComprehension.apply(l, r, :highest, "separator", &do_high_low/3)
       :lowest -> ListComprehension.apply(l, r, :lowest, "separator", &do_high_low/3)
       _ -> ListComprehension.apply(l, r, :highest, "separator", &do_high_low/3)

--- a/lib/compilers/variable.ex
+++ b/lib/compilers/variable.ex
@@ -40,7 +40,7 @@ defmodule ExDiceRoller.Compilers.Variable do
   """
 
   @behaviour ExDiceRoller.Compiler
-  alias ExDiceRoller.{Compiler, Tokenizer, Parser}
+  alias ExDiceRoller.{Args, Compiler, Tokenizer, Parser}
 
   @impl true
   def compile({:var, _} = var), do: compile_var(var)
@@ -53,7 +53,7 @@ defmodule ExDiceRoller.Compilers.Variable do
     key = var |> to_string() |> String.to_atom()
 
     args
-    |> Keyword.get(key)
+    |> Args.get_var(key)
     |> var_final_arg(var, args)
   end
 

--- a/lib/ex_dice_roller.ex
+++ b/lib/ex_dice_roller.ex
@@ -213,7 +213,7 @@ defmodule ExDiceRoller do
 
   """
 
-  alias ExDiceRoller.{Cache, Compiler, Parser, Tokenizer}
+  alias ExDiceRoller.{Args, Cache, Compiler, Parser, Tokenizer}
 
   @cache_table Application.fetch_env!(:ex_dice_roller, :cache_table)
 
@@ -229,7 +229,7 @@ defmodule ExDiceRoller do
   variables, use `roll/3` instead.
   """
   @spec roll(String.t()) :: integer | list(integer)
-  def roll(roll_string), do: roll(roll_string, [])
+  def roll(roll_string), do: roll(roll_string, opts: [])
 
   @doc """
   Processes a given string as a dice roll and returns the calculated result. The
@@ -288,7 +288,7 @@ defmodule ExDiceRoller do
   @spec roll(String.t() | Compiler.compiled_fun(), Keyword.t()) :: integer
 
   def roll(roll_string, args) when is_bitstring(roll_string) do
-    case Keyword.get(args, :cache, false) do
+    case Args.use_cache?(args) do
       false ->
         with {:ok, tokens} <- Tokenizer.tokenize(roll_string),
              {:ok, parsed_tokens} <- Parser.parse(tokens) do

--- a/test/randomized_rolls_test.exs
+++ b/test/randomized_rolls_test.exs
@@ -52,4 +52,16 @@ defmodule ExDiceRoller.RandomizedRollsTest do
       []
     )
   end
+
+  test "intentionally fail a task" do
+    {:ok, pid} = Task.Supervisor.start_link()
+
+    RandomizedRolls.execute_roll(
+      pid,
+      "100d100d100d10000, 100d100d100d100d10000",
+      [opts: :keep],
+      [],
+      []
+    )
+  end
 end


### PR DESCRIPTION
* consolidates arguments usage throughout ExDiceRoller's internal operations, moving them to `ExDiceRoller.Args`.